### PR TITLE
Prepare for release

### DIFF
--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -14,7 +14,7 @@ jobs:
         run: npm run ci
 
       - name: Perform 'setup-matlab'
-        uses: matlab-actions/setup-matlab
+        uses: matlab-actions/setup-matlab@v0
         env:
           MATHWORKS_TOKEN: ${{ secrets.MATHWORKS_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: '12'
       - name: Perform npm tasks
-        run: npm ci && npm run build && npm run package
+        run: npm run ci
 
       - name: Set release vars
         id: release_helpers

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,19 +32,19 @@
             }
         },
         "@babel/core": {
-            "version": "7.11.6",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
-            "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
+            "version": "7.12.9",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.9.tgz",
+            "integrity": "sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.11.6",
-                "@babel/helper-module-transforms": "^7.11.0",
-                "@babel/helpers": "^7.10.4",
-                "@babel/parser": "^7.11.5",
-                "@babel/template": "^7.10.4",
-                "@babel/traverse": "^7.11.5",
-                "@babel/types": "^7.11.5",
+                "@babel/generator": "^7.12.5",
+                "@babel/helper-module-transforms": "^7.12.1",
+                "@babel/helpers": "^7.12.5",
+                "@babel/parser": "^7.12.7",
+                "@babel/template": "^7.12.7",
+                "@babel/traverse": "^7.12.9",
+                "@babel/types": "^7.12.7",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.1",
@@ -64,12 +64,12 @@
             }
         },
         "@babel/generator": {
-            "version": "7.11.6",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-            "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+            "version": "7.12.5",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
+            "integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.11.5",
+                "@babel/types": "^7.12.5",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             },
@@ -103,45 +103,47 @@
             }
         },
         "@babel/helper-member-expression-to-functions": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-            "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+            "version": "7.12.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+            "integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.11.0"
+                "@babel/types": "^7.12.7"
             }
         },
         "@babel/helper-module-imports": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-            "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+            "version": "7.12.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+            "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.4"
+                "@babel/types": "^7.12.5"
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
-            "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+            "integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.10.4",
-                "@babel/helper-replace-supers": "^7.10.4",
-                "@babel/helper-simple-access": "^7.10.4",
+                "@babel/helper-module-imports": "^7.12.1",
+                "@babel/helper-replace-supers": "^7.12.1",
+                "@babel/helper-simple-access": "^7.12.1",
                 "@babel/helper-split-export-declaration": "^7.11.0",
+                "@babel/helper-validator-identifier": "^7.10.4",
                 "@babel/template": "^7.10.4",
-                "@babel/types": "^7.11.0",
+                "@babel/traverse": "^7.12.1",
+                "@babel/types": "^7.12.1",
                 "lodash": "^4.17.19"
             }
         },
         "@babel/helper-optimise-call-expression": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-            "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+            "version": "7.12.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.7.tgz",
+            "integrity": "sha512-I5xc9oSJ2h59OwyUqjv95HRyzxj53DAubUERgQMrpcCEYQyToeHA+NEcUEsVWB4j53RDeskeBJ0SgRAYHDBckw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.4"
+                "@babel/types": "^7.12.7"
             }
         },
         "@babel/helper-plugin-utils": {
@@ -151,25 +153,24 @@
             "dev": true
         },
         "@babel/helper-replace-supers": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-            "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+            "version": "7.12.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
+            "integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
             "dev": true,
             "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.10.4",
+                "@babel/helper-member-expression-to-functions": "^7.12.1",
                 "@babel/helper-optimise-call-expression": "^7.10.4",
-                "@babel/traverse": "^7.10.4",
-                "@babel/types": "^7.10.4"
+                "@babel/traverse": "^7.12.5",
+                "@babel/types": "^7.12.5"
             }
         },
         "@babel/helper-simple-access": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-            "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+            "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
+                "@babel/types": "^7.12.1"
             }
         },
         "@babel/helper-split-export-declaration": {
@@ -188,14 +189,14 @@
             "dev": true
         },
         "@babel/helpers": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
-            "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+            "version": "7.12.5",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
+            "integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
             "dev": true,
             "requires": {
                 "@babel/template": "^7.10.4",
-                "@babel/traverse": "^7.10.4",
-                "@babel/types": "^7.10.4"
+                "@babel/traverse": "^7.12.5",
+                "@babel/types": "^7.12.5"
             }
         },
         "@babel/highlight": {
@@ -262,9 +263,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.11.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-            "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+            "version": "7.12.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.7.tgz",
+            "integrity": "sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==",
             "dev": true
         },
         "@babel/plugin-syntax-async-generators": {
@@ -286,9 +287,9 @@
             }
         },
         "@babel/plugin-syntax-class-properties": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
-            "integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.1.tgz",
+            "integrity": "sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
@@ -366,38 +367,47 @@
                 "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
+        "@babel/plugin-syntax-top-level-await": {
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz",
+            "integrity": "sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
         "@babel/template": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-            "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+            "version": "7.12.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+            "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4"
+                "@babel/parser": "^7.12.7",
+                "@babel/types": "^7.12.7"
             }
         },
         "@babel/traverse": {
-            "version": "7.11.5",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-            "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+            "version": "7.12.9",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.9.tgz",
+            "integrity": "sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.11.5",
+                "@babel/generator": "^7.12.5",
                 "@babel/helper-function-name": "^7.10.4",
                 "@babel/helper-split-export-declaration": "^7.11.0",
-                "@babel/parser": "^7.11.5",
-                "@babel/types": "^7.11.5",
+                "@babel/parser": "^7.12.7",
+                "@babel/types": "^7.12.7",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0",
                 "lodash": "^4.17.19"
             }
         },
         "@babel/types": {
-            "version": "7.11.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-            "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+            "version": "7.12.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
+            "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
             "dev": true,
             "requires": {
                 "@babel/helper-validator-identifier": "^7.10.4",
@@ -441,273 +451,103 @@
             "dev": true
         },
         "@jest/console": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.3.0.tgz",
-            "integrity": "sha512-/5Pn6sJev0nPUcAdpJHMVIsA8sKizL2ZkcKPE5+dJrCccks7tcM7c9wbgHudBJbxXLoTbqsHkG1Dofoem4F09w==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.6.2.tgz",
+            "integrity": "sha512-IY1R2i2aLsLr7Id3S6p2BA82GNWryt4oSvEXLAKc+L2zdi89dSkE8xC1C+0kpATG4JhBJREnQOH7/zmccM2B0g==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.3.0",
+                "@jest/types": "^26.6.2",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
-                "jest-message-util": "^26.3.0",
-                "jest-util": "^26.3.0",
+                "jest-message-util": "^26.6.2",
+                "jest-util": "^26.6.2",
                 "slash": "^3.0.0"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
             }
         },
         "@jest/core": {
-            "version": "26.4.2",
-            "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.4.2.tgz",
-            "integrity": "sha512-sDva7YkeNprxJfepOctzS8cAk9TOekldh+5FhVuXS40+94SHbiicRO1VV2tSoRtgIo+POs/Cdyf8p76vPTd6dg==",
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.3.tgz",
+            "integrity": "sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==",
             "dev": true,
             "requires": {
-                "@jest/console": "^26.3.0",
-                "@jest/reporters": "^26.4.1",
-                "@jest/test-result": "^26.3.0",
-                "@jest/transform": "^26.3.0",
-                "@jest/types": "^26.3.0",
+                "@jest/console": "^26.6.2",
+                "@jest/reporters": "^26.6.2",
+                "@jest/test-result": "^26.6.2",
+                "@jest/transform": "^26.6.2",
+                "@jest/types": "^26.6.2",
                 "@types/node": "*",
                 "ansi-escapes": "^4.2.1",
                 "chalk": "^4.0.0",
                 "exit": "^0.1.2",
                 "graceful-fs": "^4.2.4",
-                "jest-changed-files": "^26.3.0",
-                "jest-config": "^26.4.2",
-                "jest-haste-map": "^26.3.0",
-                "jest-message-util": "^26.3.0",
+                "jest-changed-files": "^26.6.2",
+                "jest-config": "^26.6.3",
+                "jest-haste-map": "^26.6.2",
+                "jest-message-util": "^26.6.2",
                 "jest-regex-util": "^26.0.0",
-                "jest-resolve": "^26.4.0",
-                "jest-resolve-dependencies": "^26.4.2",
-                "jest-runner": "^26.4.2",
-                "jest-runtime": "^26.4.2",
-                "jest-snapshot": "^26.4.2",
-                "jest-util": "^26.3.0",
-                "jest-validate": "^26.4.2",
-                "jest-watcher": "^26.3.0",
+                "jest-resolve": "^26.6.2",
+                "jest-resolve-dependencies": "^26.6.3",
+                "jest-runner": "^26.6.3",
+                "jest-runtime": "^26.6.3",
+                "jest-snapshot": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "jest-validate": "^26.6.2",
+                "jest-watcher": "^26.6.2",
                 "micromatch": "^4.0.2",
                 "p-each-series": "^2.1.0",
                 "rimraf": "^3.0.0",
                 "slash": "^3.0.0",
                 "strip-ansi": "^6.0.0"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
             }
         },
         "@jest/environment": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.3.0.tgz",
-            "integrity": "sha512-EW+MFEo0DGHahf83RAaiqQx688qpXgl99wdb8Fy67ybyzHwR1a58LHcO376xQJHfmoXTu89M09dH3J509cx2AA==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.2.tgz",
+            "integrity": "sha512-nFy+fHl28zUrRsCeMB61VDThV1pVTtlEokBRgqPrcT1JNq4yRNIyTHfyht6PqtUvY9IsuLGTrbG8kPXjSZIZwA==",
             "dev": true,
             "requires": {
-                "@jest/fake-timers": "^26.3.0",
-                "@jest/types": "^26.3.0",
+                "@jest/fake-timers": "^26.6.2",
+                "@jest/types": "^26.6.2",
                 "@types/node": "*",
-                "jest-mock": "^26.3.0"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
+                "jest-mock": "^26.6.2"
             }
         },
         "@jest/fake-timers": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.3.0.tgz",
-            "integrity": "sha512-ZL9ytUiRwVP8ujfRepffokBvD2KbxbqMhrXSBhSdAhISCw3gOkuntisiSFv+A6HN0n0fF4cxzICEKZENLmW+1A==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.2.tgz",
+            "integrity": "sha512-14Uleatt7jdzefLPYM3KLcnUl1ZNikaKq34enpb5XG9i81JpppDb5muZvonvKyrl7ftEHkKS5L5/eB/kxJ+bvA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.3.0",
+                "@jest/types": "^26.6.2",
                 "@sinonjs/fake-timers": "^6.0.1",
                 "@types/node": "*",
-                "jest-message-util": "^26.3.0",
-                "jest-mock": "^26.3.0",
-                "jest-util": "^26.3.0"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
+                "jest-message-util": "^26.6.2",
+                "jest-mock": "^26.6.2",
+                "jest-util": "^26.6.2"
             }
         },
         "@jest/globals": {
-            "version": "26.4.2",
-            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.4.2.tgz",
-            "integrity": "sha512-Ot5ouAlehhHLRhc+sDz2/9bmNv9p5ZWZ9LE1pXGGTCXBasmi5jnYjlgYcYt03FBwLmZXCZ7GrL29c33/XRQiow==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.6.2.tgz",
+            "integrity": "sha512-85Ltnm7HlB/KesBUuALwQ68YTU72w9H2xW9FjZ1eL1U3lhtefjjl5c2MiUbpXt/i6LaPRvoOFJ22yCBSfQ0JIA==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^26.3.0",
-                "@jest/types": "^26.3.0",
-                "expect": "^26.4.2"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
+                "@jest/environment": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "expect": "^26.6.2"
             }
         },
         "@jest/reporters": {
-            "version": "26.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.4.1.tgz",
-            "integrity": "sha512-aROTkCLU8++yiRGVxLsuDmZsQEKO6LprlrxtAuzvtpbIFl3eIjgIf3EUxDKgomkS25R9ZzwGEdB5weCcBZlrpQ==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.2.tgz",
+            "integrity": "sha512-h2bW53APG4HvkOnVMo8q3QXa6pcaNt1HkwVsOPMBV6LD/q9oSpxNSYZQYkAnjdMjrJ86UuYeLo+aEZClV6opnw==",
             "dev": true,
             "requires": {
                 "@bcoe/v8-coverage": "^0.2.3",
-                "@jest/console": "^26.3.0",
-                "@jest/test-result": "^26.3.0",
-                "@jest/transform": "^26.3.0",
-                "@jest/types": "^26.3.0",
+                "@jest/console": "^26.6.2",
+                "@jest/test-result": "^26.6.2",
+                "@jest/transform": "^26.6.2",
+                "@jest/types": "^26.6.2",
                 "chalk": "^4.0.0",
                 "collect-v8-coverage": "^1.0.0",
                 "exit": "^0.1.2",
@@ -718,56 +558,22 @@
                 "istanbul-lib-report": "^3.0.0",
                 "istanbul-lib-source-maps": "^4.0.0",
                 "istanbul-reports": "^3.0.2",
-                "jest-haste-map": "^26.3.0",
-                "jest-resolve": "^26.4.0",
-                "jest-util": "^26.3.0",
-                "jest-worker": "^26.3.0",
+                "jest-haste-map": "^26.6.2",
+                "jest-resolve": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "jest-worker": "^26.6.2",
                 "node-notifier": "^8.0.0",
                 "slash": "^3.0.0",
                 "source-map": "^0.6.0",
                 "string-length": "^4.0.1",
                 "terminal-link": "^2.0.0",
-                "v8-to-istanbul": "^5.0.1"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
+                "v8-to-istanbul": "^7.0.0"
             }
         },
         "@jest/source-map": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.3.0.tgz",
-            "integrity": "sha512-hWX5IHmMDWe1kyrKl7IhFwqOuAreIwHhbe44+XH2ZRHjrKIh0LO5eLQ/vxHFeAfRwJapmxuqlGAEYLadDq6ZGQ==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.6.2.tgz",
+            "integrity": "sha512-YwYcCwAnNmOVsZ8mr3GfnzdXDAl4LaenZP5z+G0c8bzC9/dugL8zRmxZzdoTl4IaS3CryS1uWnROLPFmb6lVvA==",
             "dev": true,
             "requires": {
                 "callsites": "^3.0.0",
@@ -776,131 +582,64 @@
             }
         },
         "@jest/test-result": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.3.0.tgz",
-            "integrity": "sha512-a8rbLqzW/q7HWheFVMtghXV79Xk+GWwOK1FrtimpI5n1la2SY0qHri3/b0/1F0Ve0/yJmV8pEhxDfVwiUBGtgg==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.2.tgz",
+            "integrity": "sha512-5O7H5c/7YlojphYNrK02LlDIV2GNPYisKwHm2QTKjNZeEzezCbwYs9swJySv2UfPMyZ0VdsmMv7jIlD/IKYQpQ==",
             "dev": true,
             "requires": {
-                "@jest/console": "^26.3.0",
-                "@jest/types": "^26.3.0",
+                "@jest/console": "^26.6.2",
+                "@jest/types": "^26.6.2",
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "collect-v8-coverage": "^1.0.0"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
             }
         },
         "@jest/test-sequencer": {
-            "version": "26.4.2",
-            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.4.2.tgz",
-            "integrity": "sha512-83DRD8N3M0tOhz9h0bn6Kl6dSp+US6DazuVF8J9m21WAp5x7CqSMaNycMP0aemC/SH/pDQQddbsfHRTBXVUgog==",
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.6.3.tgz",
+            "integrity": "sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==",
             "dev": true,
             "requires": {
-                "@jest/test-result": "^26.3.0",
+                "@jest/test-result": "^26.6.2",
                 "graceful-fs": "^4.2.4",
-                "jest-haste-map": "^26.3.0",
-                "jest-runner": "^26.4.2",
-                "jest-runtime": "^26.4.2"
+                "jest-haste-map": "^26.6.2",
+                "jest-runner": "^26.6.3",
+                "jest-runtime": "^26.6.3"
             }
         },
         "@jest/transform": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.3.0.tgz",
-            "integrity": "sha512-Isj6NB68QorGoFWvcOjlUhpkT56PqNIsXKR7XfvoDlCANn/IANlh8DrKAA2l2JKC3yWSMH5wS0GwuQM20w3b2A==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.2.tgz",
+            "integrity": "sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.1.0",
-                "@jest/types": "^26.3.0",
+                "@jest/types": "^26.6.2",
                 "babel-plugin-istanbul": "^6.0.0",
                 "chalk": "^4.0.0",
                 "convert-source-map": "^1.4.0",
                 "fast-json-stable-stringify": "^2.0.0",
                 "graceful-fs": "^4.2.4",
-                "jest-haste-map": "^26.3.0",
+                "jest-haste-map": "^26.6.2",
                 "jest-regex-util": "^26.0.0",
-                "jest-util": "^26.3.0",
+                "jest-util": "^26.6.2",
                 "micromatch": "^4.0.2",
                 "pirates": "^4.0.1",
                 "slash": "^3.0.0",
                 "source-map": "^0.6.1",
                 "write-file-atomic": "^3.0.0"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
             }
         },
         "@jest/types": {
-            "version": "25.5.0",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-            "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+            "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
             "dev": true,
             "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^1.1.1",
+                "@types/istanbul-reports": "^3.0.0",
+                "@types/node": "*",
                 "@types/yargs": "^15.0.0",
-                "chalk": "^3.0.0"
+                "chalk": "^4.0.0"
             }
         },
         "@sinonjs/commons": {
@@ -922,9 +661,9 @@
             }
         },
         "@types/babel__core": {
-            "version": "7.1.10",
-            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.10.tgz",
-            "integrity": "sha512-x8OM8XzITIMyiwl5Vmo2B1cR1S1Ipkyv4mdlbJjMa1lmuKvKY9FrBbEANIaMlnWn5Rf7uO+rC/VgYabNkE17Hw==",
+            "version": "7.1.12",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
+            "integrity": "sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==",
             "dev": true,
             "requires": {
                 "@babel/parser": "^7.1.0",
@@ -944,9 +683,9 @@
             }
         },
         "@types/babel__template": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.3.tgz",
-            "integrity": "sha512-uCoznIPDmnickEi6D0v11SBpW0OuVqHJCa7syXqQHy5uktSCreIlt0iglsCnmvz8yCb38hGcWeseA8cWJSwv5Q==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
+            "integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
             "dev": true,
             "requires": {
                 "@babel/parser": "^7.1.0",
@@ -954,24 +693,18 @@
             }
         },
         "@types/babel__traverse": {
-            "version": "7.0.15",
-            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.15.tgz",
-            "integrity": "sha512-Pzh9O3sTK8V6I1olsXpCfj2k/ygO2q1X0vhhnDrEQyYLHZesWz+zMZMVcwXLCYf0U36EtmyYaFGPfXlTtDHe3A==",
+            "version": "7.0.16",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.16.tgz",
+            "integrity": "sha512-S63Dt4CZOkuTmpLGGWtT/mQdVORJOpx6SZWGVaP56dda/0Nx5nEe82K7/LAm8zYr6SfMq+1N2OreIOrHAx656w==",
             "dev": true,
             "requires": {
                 "@babel/types": "^7.3.0"
             }
         },
-        "@types/color-name": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-            "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-            "dev": true
-        },
         "@types/graceful-fs": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
-            "integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.4.tgz",
+            "integrity": "sha512-mWA/4zFQhfvOA8zWkXobwJvBD7vzcxgrOQ0J5CH1votGqdq9m7+FwtGaqyCZqC3NyyBkc9z4m+iry4LlqcMWJg==",
             "dev": true,
             "requires": {
                 "@types/node": "*"
@@ -993,29 +726,28 @@
             }
         },
         "@types/istanbul-reports": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-            "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+            "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
             "dev": true,
             "requires": {
-                "@types/istanbul-lib-coverage": "*",
                 "@types/istanbul-lib-report": "*"
             }
         },
         "@types/jest": {
-            "version": "26.0.14",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.14.tgz",
-            "integrity": "sha512-Hz5q8Vu0D288x3iWXePSn53W7hAjP0H7EQ6QvDO9c7t46mR0lNOLlfuwQ+JkVxuhygHzlzPX+0jKdA3ZgSh+Vg==",
+            "version": "26.0.15",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.15.tgz",
+            "integrity": "sha512-s2VMReFXRg9XXxV+CW9e5Nz8fH2K1aEhwgjUqPPbQd7g95T0laAcvLv032EhFHIa5GHsZ8W7iJEQVaJq6k3Gog==",
             "dev": true,
             "requires": {
-                "jest-diff": "^25.2.1",
-                "pretty-format": "^25.2.1"
+                "jest-diff": "^26.0.0",
+                "pretty-format": "^26.0.0"
             }
         },
         "@types/node": {
-            "version": "14.11.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
-            "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
+            "version": "14.14.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
+            "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==",
             "dev": true
         },
         "@types/normalize-package-data": {
@@ -1025,15 +757,15 @@
             "dev": true
         },
         "@types/prettier": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.1.tgz",
-            "integrity": "sha512-2zs+O+UkDsJ1Vcp667pd3f8xearMdopz/z54i99wtRDI5KLmngk7vlrYZD0ZjKHaROR03EznlBbVY9PfAEyJIQ==",
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.5.tgz",
+            "integrity": "sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ==",
             "dev": true
         },
         "@types/stack-utils": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
-            "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+            "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
             "dev": true
         },
         "@types/uuid": {
@@ -1043,9 +775,9 @@
             "dev": true
         },
         "@types/yargs": {
-            "version": "15.0.7",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
-            "integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+            "version": "15.0.10",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.10.tgz",
+            "integrity": "sha512-z8PNtlhrj7eJNLmrAivM7rjBESG6JwC5xP3RVk12i/8HVP7Xnx/sEmERnRImyEuUaJfO942X0qMOYsoupaJbZQ==",
             "dev": true,
             "requires": {
                 "@types/yargs-parser": "*"
@@ -1070,9 +802,9 @@
             "dev": true
         },
         "acorn": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-            "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
             "dev": true
         },
         "acorn-globals": {
@@ -1092,9 +824,9 @@
             "dev": true
         },
         "ajv": {
-            "version": "6.12.5",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-            "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
@@ -1127,12 +859,11 @@
             "dev": true
         },
         "ansi-styles": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-            "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
             "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
             }
         },
@@ -1219,59 +950,25 @@
             "dev": true
         },
         "aws4": {
-            "version": "1.10.1",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-            "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+            "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
             "dev": true
         },
         "babel-jest": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.3.0.tgz",
-            "integrity": "sha512-sxPnQGEyHAOPF8NcUsD0g7hDCnvLL2XyblRBcgrzTWBB/mAIpWow3n1bEL+VghnnZfreLhFSBsFluRoK2tRK4g==",
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
+            "integrity": "sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==",
             "dev": true,
             "requires": {
-                "@jest/transform": "^26.3.0",
-                "@jest/types": "^26.3.0",
+                "@jest/transform": "^26.6.2",
+                "@jest/types": "^26.6.2",
                 "@types/babel__core": "^7.1.7",
                 "babel-plugin-istanbul": "^6.0.0",
-                "babel-preset-jest": "^26.3.0",
+                "babel-preset-jest": "^26.6.2",
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.4",
                 "slash": "^3.0.0"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
             }
         },
         "babel-plugin-istanbul": {
@@ -1288,9 +985,9 @@
             }
         },
         "babel-plugin-jest-hoist": {
-            "version": "26.2.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.2.0.tgz",
-            "integrity": "sha512-B/hVMRv8Nh1sQ1a3EY8I0n4Y1Wty3NrR5ebOyVT302op+DOAau+xNEImGMsUWOC3++ZlMooCytKz+NgN8aKGbA==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2.tgz",
+            "integrity": "sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==",
             "dev": true,
             "requires": {
                 "@babel/template": "^7.3.3",
@@ -1300,9 +997,9 @@
             }
         },
         "babel-preset-current-node-syntax": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz",
-            "integrity": "sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.0.tgz",
+            "integrity": "sha512-mGkvkpocWJes1CmMKtgGUwCeeq0pOhALyymozzDWYomHTbDLwueDYG6p4TK1YOeYHCzBzYPsWkgTto10JubI1Q==",
             "dev": true,
             "requires": {
                 "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -1315,17 +1012,18 @@
                 "@babel/plugin-syntax-numeric-separator": "^7.8.3",
                 "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
                 "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-                "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+                "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+                "@babel/plugin-syntax-top-level-await": "^7.8.3"
             }
         },
         "babel-preset-jest": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.3.0.tgz",
-            "integrity": "sha512-5WPdf7nyYi2/eRxCbVrE1kKCWxgWY4RsPEbdJWFm7QsesFGqjdkyLeu1zRkwM1cxK6EPIlNd6d2AxLk7J+t4pw==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz",
+            "integrity": "sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==",
             "dev": true,
             "requires": {
-                "babel-plugin-jest-hoist": "^26.2.0",
-                "babel-preset-current-node-syntax": "^0.1.3"
+                "babel-plugin-jest-hoist": "^26.6.2",
+                "babel-preset-current-node-syntax": "^1.0.0"
             }
         },
         "balanced-match": {
@@ -1492,9 +1190,9 @@
             "dev": true
         },
         "chalk": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-            "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+            "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
             "dev": true,
             "requires": {
                 "ansi-styles": "^4.1.0",
@@ -1511,6 +1209,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
             "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+            "dev": true
+        },
+        "cjs-module-lexer": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz",
+            "integrity": "sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw==",
             "dev": true
         },
         "class-utils": {
@@ -1683,9 +1387,9 @@
             }
         },
         "debug": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-            "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
             "dev": true,
             "requires": {
                 "ms": "2.1.2"
@@ -1781,9 +1485,9 @@
             "dev": true
         },
         "diff-sequences": {
-            "version": "25.2.6",
-            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
-            "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
+            "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
             "dev": true
         },
         "domexception": {
@@ -1814,9 +1518,9 @@
             }
         },
         "emittery": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.1.tgz",
-            "integrity": "sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
+            "integrity": "sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==",
             "dev": true
         },
         "emoji-regex": {
@@ -1958,57 +1662,17 @@
             }
         },
         "expect": {
-            "version": "26.4.2",
-            "resolved": "https://registry.npmjs.org/expect/-/expect-26.4.2.tgz",
-            "integrity": "sha512-IlJ3X52Z0lDHm7gjEp+m76uX46ldH5VpqmU0006vqDju/285twh7zaWMRhs67VpQhBwjjMchk+p5aA0VkERCAA==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz",
+            "integrity": "sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.3.0",
+                "@jest/types": "^26.6.2",
                 "ansi-styles": "^4.0.0",
                 "jest-get-type": "^26.3.0",
-                "jest-matcher-utils": "^26.4.2",
-                "jest-message-util": "^26.3.0",
+                "jest-matcher-utils": "^26.6.2",
+                "jest-message-util": "^26.6.2",
                 "jest-regex-util": "^26.0.0"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "jest-get-type": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-                    "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-                    "dev": true
-                }
             }
         },
         "extend": {
@@ -2194,16 +1858,22 @@
             "dev": true
         },
         "fsevents": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-            "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.2.1.tgz",
+            "integrity": "sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==",
             "dev": true,
             "optional": true
         },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
         "gensync": {
-            "version": "1.0.0-beta.1",
-            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-            "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+            "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
             "dev": true
         },
         "get-caller-file": {
@@ -2289,6 +1959,15 @@
             "requires": {
                 "ajv": "^6.12.3",
                 "har-schema": "^2.0.0"
+            }
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1"
             }
         },
         "has-flag": {
@@ -2473,6 +2152,15 @@
             "dev": true,
             "requires": {
                 "ci-info": "^2.0.0"
+            }
+        },
+        "is-core-module": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+            "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.3"
             }
         },
         "is-data-descriptor": {
@@ -2671,114 +2359,50 @@
             }
         },
         "jest": {
-            "version": "26.4.2",
-            "resolved": "https://registry.npmjs.org/jest/-/jest-26.4.2.tgz",
-            "integrity": "sha512-LLCjPrUh98Ik8CzW8LLVnSCfLaiY+wbK53U7VxnFSX7Q+kWC4noVeDvGWIFw0Amfq1lq2VfGm7YHWSLBV62MJw==",
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-26.6.3.tgz",
+            "integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
             "dev": true,
             "requires": {
-                "@jest/core": "^26.4.2",
+                "@jest/core": "^26.6.3",
                 "import-local": "^3.0.2",
-                "jest-cli": "^26.4.2"
+                "jest-cli": "^26.6.3"
             },
             "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
                 "jest-cli": {
-                    "version": "26.4.2",
-                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.4.2.tgz",
-                    "integrity": "sha512-zb+lGd/SfrPvoRSC/0LWdaWCnscXc1mGYW//NP4/tmBvRPT3VntZ2jtKUONsRi59zc5JqmsSajA9ewJKFYp8Cw==",
+                    "version": "26.6.3",
+                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
+                    "integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
                     "dev": true,
                     "requires": {
-                        "@jest/core": "^26.4.2",
-                        "@jest/test-result": "^26.3.0",
-                        "@jest/types": "^26.3.0",
+                        "@jest/core": "^26.6.3",
+                        "@jest/test-result": "^26.6.2",
+                        "@jest/types": "^26.6.2",
                         "chalk": "^4.0.0",
                         "exit": "^0.1.2",
                         "graceful-fs": "^4.2.4",
                         "import-local": "^3.0.2",
                         "is-ci": "^2.0.0",
-                        "jest-config": "^26.4.2",
-                        "jest-util": "^26.3.0",
-                        "jest-validate": "^26.4.2",
+                        "jest-config": "^26.6.3",
+                        "jest-util": "^26.6.2",
+                        "jest-validate": "^26.6.2",
                         "prompts": "^2.0.1",
-                        "yargs": "^15.3.1"
+                        "yargs": "^15.4.1"
                     }
                 }
             }
         },
         "jest-changed-files": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.3.0.tgz",
-            "integrity": "sha512-1C4R4nijgPltX6fugKxM4oQ18zimS7LqQ+zTTY8lMCMFPrxqBFb7KJH0Z2fRQJvw2Slbaipsqq7s1mgX5Iot+g==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.2.tgz",
+            "integrity": "sha512-fDS7szLcY9sCtIip8Fjry9oGf3I2ht/QT21bAHm5Dmf0mD4X3ReNUf17y+bO6fR8WgbIZTlbyG1ak/53cbRzKQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.3.0",
+                "@jest/types": "^26.6.2",
                 "execa": "^4.0.0",
                 "throat": "^5.0.0"
             },
             "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
                 "cross-spawn": {
                     "version": "7.0.3",
                     "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2791,9 +2415,9 @@
                     }
                 },
                 "execa": {
-                    "version": "4.0.3",
-                    "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-                    "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+                    "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
                     "dev": true,
                     "requires": {
                         "cross-spawn": "^7.0.0",
@@ -2864,167 +2488,70 @@
             }
         },
         "jest-circus": {
-            "version": "26.4.2",
-            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-26.4.2.tgz",
-            "integrity": "sha512-gzxoteivskdUTNxT7Jx6hrANsEm+x1wh8jaXmQCtzC7zoNWirk9chYdSosHFC4tJlfDZa0EsPreVAxLicLsV0w==",
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-26.6.3.tgz",
+            "integrity": "sha512-ACrpWZGcQMpbv13XbzRzpytEJlilP/Su0JtNCi5r/xLpOUhnaIJr8leYYpLEMgPFURZISEHrnnpmB54Q/UziPw==",
             "dev": true,
             "requires": {
                 "@babel/traverse": "^7.1.0",
-                "@jest/environment": "^26.3.0",
-                "@jest/test-result": "^26.3.0",
-                "@jest/types": "^26.3.0",
+                "@jest/environment": "^26.6.2",
+                "@jest/test-result": "^26.6.2",
+                "@jest/types": "^26.6.2",
+                "@types/babel__traverse": "^7.0.4",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "co": "^4.6.0",
                 "dedent": "^0.7.0",
-                "expect": "^26.4.2",
+                "expect": "^26.6.2",
                 "is-generator-fn": "^2.0.0",
-                "jest-each": "^26.4.2",
-                "jest-matcher-utils": "^26.4.2",
-                "jest-message-util": "^26.3.0",
-                "jest-runner": "^26.4.2",
-                "jest-runtime": "^26.4.2",
-                "jest-snapshot": "^26.4.2",
-                "jest-util": "^26.3.0",
-                "pretty-format": "^26.4.2",
+                "jest-each": "^26.6.2",
+                "jest-matcher-utils": "^26.6.2",
+                "jest-message-util": "^26.6.2",
+                "jest-runner": "^26.6.3",
+                "jest-runtime": "^26.6.3",
+                "jest-snapshot": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "pretty-format": "^26.6.2",
                 "stack-utils": "^2.0.2",
                 "throat": "^5.0.0"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "pretty-format": {
-                    "version": "26.4.2",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-                    "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
-                    "dev": true,
-                    "requires": {
-                        "@jest/types": "^26.3.0",
-                        "ansi-regex": "^5.0.0",
-                        "ansi-styles": "^4.0.0",
-                        "react-is": "^16.12.0"
-                    }
-                }
             }
         },
         "jest-config": {
-            "version": "26.4.2",
-            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.4.2.tgz",
-            "integrity": "sha512-QBf7YGLuToiM8PmTnJEdRxyYy3mHWLh24LJZKVdXZ2PNdizSe1B/E8bVm+HYcjbEzGuVXDv/di+EzdO/6Gq80A==",
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.6.3.tgz",
+            "integrity": "sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.1.0",
-                "@jest/test-sequencer": "^26.4.2",
-                "@jest/types": "^26.3.0",
-                "babel-jest": "^26.3.0",
+                "@jest/test-sequencer": "^26.6.3",
+                "@jest/types": "^26.6.2",
+                "babel-jest": "^26.6.3",
                 "chalk": "^4.0.0",
                 "deepmerge": "^4.2.2",
                 "glob": "^7.1.1",
                 "graceful-fs": "^4.2.4",
-                "jest-environment-jsdom": "^26.3.0",
-                "jest-environment-node": "^26.3.0",
+                "jest-environment-jsdom": "^26.6.2",
+                "jest-environment-node": "^26.6.2",
                 "jest-get-type": "^26.3.0",
-                "jest-jasmine2": "^26.4.2",
+                "jest-jasmine2": "^26.6.3",
                 "jest-regex-util": "^26.0.0",
-                "jest-resolve": "^26.4.0",
-                "jest-util": "^26.3.0",
-                "jest-validate": "^26.4.2",
+                "jest-resolve": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "jest-validate": "^26.6.2",
                 "micromatch": "^4.0.2",
-                "pretty-format": "^26.4.2"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "jest-get-type": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-                    "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-                    "dev": true
-                },
-                "pretty-format": {
-                    "version": "26.4.2",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-                    "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
-                    "dev": true,
-                    "requires": {
-                        "@jest/types": "^26.3.0",
-                        "ansi-regex": "^5.0.0",
-                        "ansi-styles": "^4.0.0",
-                        "react-is": "^16.12.0"
-                    }
-                }
+                "pretty-format": "^26.6.2"
             }
         },
         "jest-diff": {
-            "version": "25.5.0",
-            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
-            "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
+            "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
             "dev": true,
             "requires": {
-                "chalk": "^3.0.0",
-                "diff-sequences": "^25.2.6",
-                "jest-get-type": "^25.2.6",
-                "pretty-format": "^25.5.0"
+                "chalk": "^4.0.0",
+                "diff-sequences": "^26.6.2",
+                "jest-get-type": "^26.3.0",
+                "pretty-format": "^26.6.2"
             }
         },
         "jest-docblock": {
@@ -3037,180 +2564,60 @@
             }
         },
         "jest-each": {
-            "version": "26.4.2",
-            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.4.2.tgz",
-            "integrity": "sha512-p15rt8r8cUcRY0Mvo1fpkOGYm7iI8S6ySxgIdfh3oOIv+gHwrHTy5VWCGOecWUhDsit4Nz8avJWdT07WLpbwDA==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.6.2.tgz",
+            "integrity": "sha512-Mer/f0KaATbjl8MCJ+0GEpNdqmnVmDYqCTJYTvoo7rqmRiDllmp2AYN+06F93nXcY3ur9ShIjS+CO/uD+BbH4A==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.3.0",
+                "@jest/types": "^26.6.2",
                 "chalk": "^4.0.0",
                 "jest-get-type": "^26.3.0",
-                "jest-util": "^26.3.0",
-                "pretty-format": "^26.4.2"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "jest-get-type": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-                    "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-                    "dev": true
-                },
-                "pretty-format": {
-                    "version": "26.4.2",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-                    "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
-                    "dev": true,
-                    "requires": {
-                        "@jest/types": "^26.3.0",
-                        "ansi-regex": "^5.0.0",
-                        "ansi-styles": "^4.0.0",
-                        "react-is": "^16.12.0"
-                    }
-                }
+                "jest-util": "^26.6.2",
+                "pretty-format": "^26.6.2"
             }
         },
         "jest-environment-jsdom": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.3.0.tgz",
-            "integrity": "sha512-zra8He2btIMJkAzvLaiZ9QwEPGEetbxqmjEBQwhH3CA+Hhhu0jSiEJxnJMbX28TGUvPLxBt/zyaTLrOPF4yMJA==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.2.tgz",
+            "integrity": "sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^26.3.0",
-                "@jest/fake-timers": "^26.3.0",
-                "@jest/types": "^26.3.0",
+                "@jest/environment": "^26.6.2",
+                "@jest/fake-timers": "^26.6.2",
+                "@jest/types": "^26.6.2",
                 "@types/node": "*",
-                "jest-mock": "^26.3.0",
-                "jest-util": "^26.3.0",
-                "jsdom": "^16.2.2"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
+                "jest-mock": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "jsdom": "^16.4.0"
             }
         },
         "jest-environment-node": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.3.0.tgz",
-            "integrity": "sha512-c9BvYoo+FGcMj5FunbBgtBnbR5qk3uky8PKyRVpSfe2/8+LrNQMiXX53z6q2kY+j15SkjQCOSL/6LHnCPLVHNw==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.2.tgz",
+            "integrity": "sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^26.3.0",
-                "@jest/fake-timers": "^26.3.0",
-                "@jest/types": "^26.3.0",
+                "@jest/environment": "^26.6.2",
+                "@jest/fake-timers": "^26.6.2",
+                "@jest/types": "^26.6.2",
                 "@types/node": "*",
-                "jest-mock": "^26.3.0",
-                "jest-util": "^26.3.0"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
+                "jest-mock": "^26.6.2",
+                "jest-util": "^26.6.2"
             }
         },
         "jest-get-type": {
-            "version": "25.2.6",
-            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
-            "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+            "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
             "dev": true
         },
         "jest-haste-map": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.3.0.tgz",
-            "integrity": "sha512-DHWBpTJgJhLLGwE5Z1ZaqLTYqeODQIZpby0zMBsCU9iRFHYyhklYqP4EiG73j5dkbaAdSZhgB938mL51Q5LeZA==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
+            "integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.3.0",
+                "@jest/types": "^26.6.2",
                 "@types/graceful-fs": "^4.1.2",
                 "@types/node": "*",
                 "anymatch": "^3.0.3",
@@ -3218,356 +2625,87 @@
                 "fsevents": "^2.1.2",
                 "graceful-fs": "^4.2.4",
                 "jest-regex-util": "^26.0.0",
-                "jest-serializer": "^26.3.0",
-                "jest-util": "^26.3.0",
-                "jest-worker": "^26.3.0",
+                "jest-serializer": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "jest-worker": "^26.6.2",
                 "micromatch": "^4.0.2",
                 "sane": "^4.0.3",
                 "walker": "^1.0.7"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
             }
         },
         "jest-jasmine2": {
-            "version": "26.4.2",
-            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.4.2.tgz",
-            "integrity": "sha512-z7H4EpCldHN1J8fNgsja58QftxBSL+JcwZmaXIvV9WKIM+x49F4GLHu/+BQh2kzRKHAgaN/E82od+8rTOBPyPA==",
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.6.3.tgz",
+            "integrity": "sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==",
             "dev": true,
             "requires": {
                 "@babel/traverse": "^7.1.0",
-                "@jest/environment": "^26.3.0",
-                "@jest/source-map": "^26.3.0",
-                "@jest/test-result": "^26.3.0",
-                "@jest/types": "^26.3.0",
+                "@jest/environment": "^26.6.2",
+                "@jest/source-map": "^26.6.2",
+                "@jest/test-result": "^26.6.2",
+                "@jest/types": "^26.6.2",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "co": "^4.6.0",
-                "expect": "^26.4.2",
+                "expect": "^26.6.2",
                 "is-generator-fn": "^2.0.0",
-                "jest-each": "^26.4.2",
-                "jest-matcher-utils": "^26.4.2",
-                "jest-message-util": "^26.3.0",
-                "jest-runtime": "^26.4.2",
-                "jest-snapshot": "^26.4.2",
-                "jest-util": "^26.3.0",
-                "pretty-format": "^26.4.2",
+                "jest-each": "^26.6.2",
+                "jest-matcher-utils": "^26.6.2",
+                "jest-message-util": "^26.6.2",
+                "jest-runtime": "^26.6.3",
+                "jest-snapshot": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "pretty-format": "^26.6.2",
                 "throat": "^5.0.0"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "pretty-format": {
-                    "version": "26.4.2",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-                    "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
-                    "dev": true,
-                    "requires": {
-                        "@jest/types": "^26.3.0",
-                        "ansi-regex": "^5.0.0",
-                        "ansi-styles": "^4.0.0",
-                        "react-is": "^16.12.0"
-                    }
-                }
             }
         },
         "jest-leak-detector": {
-            "version": "26.4.2",
-            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.4.2.tgz",
-            "integrity": "sha512-akzGcxwxtE+9ZJZRW+M2o+nTNnmQZxrHJxX/HjgDaU5+PLmY1qnQPnMjgADPGCRPhB+Yawe1iij0REe+k/aHoA==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz",
+            "integrity": "sha512-i4xlXpsVSMeKvg2cEKdfhh0H39qlJlP5Ex1yQxwF9ubahboQYMgTtz5oML35AVA3B4Eu+YsmwaiKVev9KCvLxg==",
             "dev": true,
             "requires": {
                 "jest-get-type": "^26.3.0",
-                "pretty-format": "^26.4.2"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "jest-get-type": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-                    "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-                    "dev": true
-                },
-                "pretty-format": {
-                    "version": "26.4.2",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-                    "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
-                    "dev": true,
-                    "requires": {
-                        "@jest/types": "^26.3.0",
-                        "ansi-regex": "^5.0.0",
-                        "ansi-styles": "^4.0.0",
-                        "react-is": "^16.12.0"
-                    }
-                }
+                "pretty-format": "^26.6.2"
             }
         },
         "jest-matcher-utils": {
-            "version": "26.4.2",
-            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
-            "integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz",
+            "integrity": "sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==",
             "dev": true,
             "requires": {
                 "chalk": "^4.0.0",
-                "jest-diff": "^26.4.2",
+                "jest-diff": "^26.6.2",
                 "jest-get-type": "^26.3.0",
-                "pretty-format": "^26.4.2"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "diff-sequences": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
-                    "integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
-                    "dev": true
-                },
-                "jest-diff": {
-                    "version": "26.4.2",
-                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
-                    "integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^4.0.0",
-                        "diff-sequences": "^26.3.0",
-                        "jest-get-type": "^26.3.0",
-                        "pretty-format": "^26.4.2"
-                    }
-                },
-                "jest-get-type": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-                    "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-                    "dev": true
-                },
-                "pretty-format": {
-                    "version": "26.4.2",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-                    "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
-                    "dev": true,
-                    "requires": {
-                        "@jest/types": "^26.3.0",
-                        "ansi-regex": "^5.0.0",
-                        "ansi-styles": "^4.0.0",
-                        "react-is": "^16.12.0"
-                    }
-                }
+                "pretty-format": "^26.6.2"
             }
         },
         "jest-message-util": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.3.0.tgz",
-            "integrity": "sha512-xIavRYqr4/otGOiLxLZGj3ieMmjcNE73Ui+LdSW/Y790j5acqCsAdDiLIbzHCZMpN07JOENRWX5DcU+OQ+TjTA==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.2.tgz",
+            "integrity": "sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
-                "@jest/types": "^26.3.0",
-                "@types/stack-utils": "^1.0.1",
+                "@jest/types": "^26.6.2",
+                "@types/stack-utils": "^2.0.0",
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.4",
                 "micromatch": "^4.0.2",
+                "pretty-format": "^26.6.2",
                 "slash": "^3.0.0",
                 "stack-utils": "^2.0.2"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
             }
         },
         "jest-mock": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.3.0.tgz",
-            "integrity": "sha512-PeaRrg8Dc6mnS35gOo/CbZovoDPKAeB1FICZiuagAgGvbWdNNyjQjkOaGUa/3N3JtpQ/Mh9P4A2D4Fv51NnP8Q==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.2.tgz",
+            "integrity": "sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.3.0",
+                "@jest/types": "^26.6.2",
                 "@types/node": "*"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
             }
         },
         "jest-pnp-resolver": {
@@ -3583,234 +2721,99 @@
             "dev": true
         },
         "jest-resolve": {
-            "version": "26.4.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.4.0.tgz",
-            "integrity": "sha512-bn/JoZTEXRSlEx3+SfgZcJAVuTMOksYq9xe9O6s4Ekg84aKBObEaVXKOEilULRqviSLAYJldnoWV9c07kwtiCg==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.2.tgz",
+            "integrity": "sha512-sOxsZOq25mT1wRsfHcbtkInS+Ek7Q8jCHUB0ZUTP0tc/c41QHriU/NunqMfCUWsL4H3MHpvQD4QR9kSYhS7UvQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.3.0",
+                "@jest/types": "^26.6.2",
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.4",
                 "jest-pnp-resolver": "^1.2.2",
-                "jest-util": "^26.3.0",
+                "jest-util": "^26.6.2",
                 "read-pkg-up": "^7.0.1",
-                "resolve": "^1.17.0",
+                "resolve": "^1.18.1",
                 "slash": "^3.0.0"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
             }
         },
         "jest-resolve-dependencies": {
-            "version": "26.4.2",
-            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.4.2.tgz",
-            "integrity": "sha512-ADHaOwqEcVc71uTfySzSowA/RdxUpCxhxa2FNLiin9vWLB1uLPad3we+JSSROq5+SrL9iYPdZZF8bdKM7XABTQ==",
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3.tgz",
+            "integrity": "sha512-pVwUjJkxbhe4RY8QEWzN3vns2kqyuldKpxlxJlzEYfKSvY6/bMvxoFrYYzUO1Gx28yKWN37qyV7rIoIp2h8fTg==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.3.0",
+                "@jest/types": "^26.6.2",
                 "jest-regex-util": "^26.0.0",
-                "jest-snapshot": "^26.4.2"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
+                "jest-snapshot": "^26.6.2"
             }
         },
         "jest-runner": {
-            "version": "26.4.2",
-            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.4.2.tgz",
-            "integrity": "sha512-FgjDHeVknDjw1gRAYaoUoShe1K3XUuFMkIaXbdhEys+1O4bEJS8Avmn4lBwoMfL8O5oFTdWYKcf3tEJyyYyk8g==",
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.3.tgz",
+            "integrity": "sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==",
             "dev": true,
             "requires": {
-                "@jest/console": "^26.3.0",
-                "@jest/environment": "^26.3.0",
-                "@jest/test-result": "^26.3.0",
-                "@jest/types": "^26.3.0",
+                "@jest/console": "^26.6.2",
+                "@jest/environment": "^26.6.2",
+                "@jest/test-result": "^26.6.2",
+                "@jest/types": "^26.6.2",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "emittery": "^0.7.1",
                 "exit": "^0.1.2",
                 "graceful-fs": "^4.2.4",
-                "jest-config": "^26.4.2",
+                "jest-config": "^26.6.3",
                 "jest-docblock": "^26.0.0",
-                "jest-haste-map": "^26.3.0",
-                "jest-leak-detector": "^26.4.2",
-                "jest-message-util": "^26.3.0",
-                "jest-resolve": "^26.4.0",
-                "jest-runtime": "^26.4.2",
-                "jest-util": "^26.3.0",
-                "jest-worker": "^26.3.0",
+                "jest-haste-map": "^26.6.2",
+                "jest-leak-detector": "^26.6.2",
+                "jest-message-util": "^26.6.2",
+                "jest-resolve": "^26.6.2",
+                "jest-runtime": "^26.6.3",
+                "jest-util": "^26.6.2",
+                "jest-worker": "^26.6.2",
                 "source-map-support": "^0.5.6",
                 "throat": "^5.0.0"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
             }
         },
         "jest-runtime": {
-            "version": "26.4.2",
-            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.4.2.tgz",
-            "integrity": "sha512-4Pe7Uk5a80FnbHwSOk7ojNCJvz3Ks2CNQWT5Z7MJo4tX0jb3V/LThKvD9tKPNVNyeMH98J/nzGlcwc00R2dSHQ==",
+            "version": "26.6.3",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.3.tgz",
+            "integrity": "sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==",
             "dev": true,
             "requires": {
-                "@jest/console": "^26.3.0",
-                "@jest/environment": "^26.3.0",
-                "@jest/fake-timers": "^26.3.0",
-                "@jest/globals": "^26.4.2",
-                "@jest/source-map": "^26.3.0",
-                "@jest/test-result": "^26.3.0",
-                "@jest/transform": "^26.3.0",
-                "@jest/types": "^26.3.0",
+                "@jest/console": "^26.6.2",
+                "@jest/environment": "^26.6.2",
+                "@jest/fake-timers": "^26.6.2",
+                "@jest/globals": "^26.6.2",
+                "@jest/source-map": "^26.6.2",
+                "@jest/test-result": "^26.6.2",
+                "@jest/transform": "^26.6.2",
+                "@jest/types": "^26.6.2",
                 "@types/yargs": "^15.0.0",
                 "chalk": "^4.0.0",
+                "cjs-module-lexer": "^0.6.0",
                 "collect-v8-coverage": "^1.0.0",
                 "exit": "^0.1.2",
                 "glob": "^7.1.3",
                 "graceful-fs": "^4.2.4",
-                "jest-config": "^26.4.2",
-                "jest-haste-map": "^26.3.0",
-                "jest-message-util": "^26.3.0",
-                "jest-mock": "^26.3.0",
+                "jest-config": "^26.6.3",
+                "jest-haste-map": "^26.6.2",
+                "jest-message-util": "^26.6.2",
+                "jest-mock": "^26.6.2",
                 "jest-regex-util": "^26.0.0",
-                "jest-resolve": "^26.4.0",
-                "jest-snapshot": "^26.4.2",
-                "jest-util": "^26.3.0",
-                "jest-validate": "^26.4.2",
+                "jest-resolve": "^26.6.2",
+                "jest-snapshot": "^26.6.2",
+                "jest-util": "^26.6.2",
+                "jest-validate": "^26.6.2",
                 "slash": "^3.0.0",
                 "strip-bom": "^4.0.0",
-                "yargs": "^15.3.1"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
+                "yargs": "^15.4.1"
             }
         },
         "jest-serializer": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.3.0.tgz",
-            "integrity": "sha512-IDRBQBLPlKa4flg77fqg0n/pH87tcRKwe8zxOVTWISxGpPHYkRZ1dXKyh04JOja7gppc60+soKVZ791mruVdow==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
+            "integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
@@ -3818,96 +2821,29 @@
             }
         },
         "jest-snapshot": {
-            "version": "26.4.2",
-            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.4.2.tgz",
-            "integrity": "sha512-N6Uub8FccKlf5SBFnL2Ri/xofbaA68Cc3MGjP/NuwgnsvWh+9hLIR/DhrxbSiKXMY9vUW5dI6EW1eHaDHqe9sg==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.2.tgz",
+            "integrity": "sha512-OLhxz05EzUtsAmOMzuupt1lHYXCNib0ECyuZ/PZOx9TrZcC8vL0x+DUG3TL+GLX3yHG45e6YGjIm0XwDc3q3og==",
             "dev": true,
             "requires": {
                 "@babel/types": "^7.0.0",
-                "@jest/types": "^26.3.0",
+                "@jest/types": "^26.6.2",
+                "@types/babel__traverse": "^7.0.4",
                 "@types/prettier": "^2.0.0",
                 "chalk": "^4.0.0",
-                "expect": "^26.4.2",
+                "expect": "^26.6.2",
                 "graceful-fs": "^4.2.4",
-                "jest-diff": "^26.4.2",
+                "jest-diff": "^26.6.2",
                 "jest-get-type": "^26.3.0",
-                "jest-haste-map": "^26.3.0",
-                "jest-matcher-utils": "^26.4.2",
-                "jest-message-util": "^26.3.0",
-                "jest-resolve": "^26.4.0",
+                "jest-haste-map": "^26.6.2",
+                "jest-matcher-utils": "^26.6.2",
+                "jest-message-util": "^26.6.2",
+                "jest-resolve": "^26.6.2",
                 "natural-compare": "^1.4.0",
-                "pretty-format": "^26.4.2",
+                "pretty-format": "^26.6.2",
                 "semver": "^7.3.2"
             },
             "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "diff-sequences": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
-                    "integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
-                    "dev": true
-                },
-                "jest-diff": {
-                    "version": "26.4.2",
-                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
-                    "integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^4.0.0",
-                        "diff-sequences": "^26.3.0",
-                        "jest-get-type": "^26.3.0",
-                        "pretty-format": "^26.4.2"
-                    }
-                },
-                "jest-get-type": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-                    "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-                    "dev": true
-                },
-                "pretty-format": {
-                    "version": "26.4.2",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-                    "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
-                    "dev": true,
-                    "requires": {
-                        "@jest/types": "^26.3.0",
-                        "ansi-regex": "^5.0.0",
-                        "ansi-styles": "^4.0.0",
-                        "react-is": "^16.12.0"
-                    }
-                },
                 "semver": {
                     "version": "7.3.2",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
@@ -3917,178 +2853,60 @@
             }
         },
         "jest-util": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
-            "integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+            "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.3.0",
+                "@jest/types": "^26.6.2",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.4",
                 "is-ci": "^2.0.0",
                 "micromatch": "^4.0.2"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
             }
         },
         "jest-validate": {
-            "version": "26.4.2",
-            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.2.tgz",
-            "integrity": "sha512-blft+xDX7XXghfhY0mrsBCYhX365n8K5wNDC4XAcNKqqjEzsRUSXP44m6PL0QJEW2crxQFLLztVnJ4j7oPlQrQ==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.2.tgz",
+            "integrity": "sha512-NEYZ9Aeyj0i5rQqbq+tpIOom0YS1u2MVu6+euBsvpgIme+FOfRmoC4R5p0JiAUpaFvFy24xgrpMknarR/93XjQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.3.0",
+                "@jest/types": "^26.6.2",
                 "camelcase": "^6.0.0",
                 "chalk": "^4.0.0",
                 "jest-get-type": "^26.3.0",
                 "leven": "^3.1.0",
-                "pretty-format": "^26.4.2"
+                "pretty-format": "^26.6.2"
             },
             "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
                 "camelcase": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-                    "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+                    "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
                     "dev": true
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "jest-get-type": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-                    "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-                    "dev": true
-                },
-                "pretty-format": {
-                    "version": "26.4.2",
-                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-                    "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
-                    "dev": true,
-                    "requires": {
-                        "@jest/types": "^26.3.0",
-                        "ansi-regex": "^5.0.0",
-                        "ansi-styles": "^4.0.0",
-                        "react-is": "^16.12.0"
-                    }
                 }
             }
         },
         "jest-watcher": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.3.0.tgz",
-            "integrity": "sha512-XnLdKmyCGJ3VoF6G/p5ohbJ04q/vv5aH9ENI+i6BL0uu9WWB6Z7Z2lhQQk0d2AVZcRGp1yW+/TsoToMhBFPRdQ==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.2.tgz",
+            "integrity": "sha512-WKJob0P/Em2csiVthsI68p6aGKTIcsfjH9Gsx1f0A3Italz43e3ho0geSAVsmj09RWOELP1AZ/DXyJgOgDKxXQ==",
             "dev": true,
             "requires": {
-                "@jest/test-result": "^26.3.0",
-                "@jest/types": "^26.3.0",
+                "@jest/test-result": "^26.6.2",
+                "@jest/types": "^26.6.2",
                 "@types/node": "*",
                 "ansi-escapes": "^4.2.1",
                 "chalk": "^4.0.0",
-                "jest-util": "^26.3.0",
+                "jest-util": "^26.6.2",
                 "string-length": "^4.0.1"
-            },
-            "dependencies": {
-                "@jest/types": {
-                    "version": "26.3.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^3.0.0",
-                        "@types/node": "*",
-                        "@types/yargs": "^15.0.0",
-                        "chalk": "^4.0.0"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                }
             }
         },
         "jest-worker": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
-            "integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+            "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
@@ -4594,9 +3412,9 @@
             }
         },
         "p-each-series": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
-            "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+            "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
             "dev": true
         },
         "p-finally": {
@@ -4720,31 +3538,31 @@
             "dev": true
         },
         "prettier": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-            "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+            "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
             "dev": true
         },
         "pretty-format": {
-            "version": "25.5.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
-            "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+            "version": "26.6.2",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+            "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
             "dev": true,
             "requires": {
-                "@jest/types": "^25.5.0",
+                "@jest/types": "^26.6.2",
                 "ansi-regex": "^5.0.0",
                 "ansi-styles": "^4.0.0",
-                "react-is": "^16.12.0"
+                "react-is": "^17.0.1"
             }
         },
         "prompts": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
-            "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
+            "integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
             "dev": true,
             "requires": {
                 "kleur": "^3.0.3",
-                "sisteransi": "^1.0.4"
+                "sisteransi": "^1.0.5"
             }
         },
         "psl": {
@@ -4776,9 +3594,9 @@
             "dev": true
         },
         "react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "version": "17.0.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+            "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
             "dev": true
         },
         "read-pkg": {
@@ -4931,11 +3749,12 @@
             "dev": true
         },
         "resolve": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-            "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+            "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
             "dev": true,
             "requires": {
+                "is-core-module": "^2.1.0",
                 "path-parse": "^1.0.6"
             }
         },
@@ -5417,9 +4236,9 @@
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
-            "integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+            "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
             "dev": true
         },
         "split-string": {
@@ -5455,9 +4274,9 @@
             }
         },
         "stack-utils": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
-            "integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
+            "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
             "dev": true,
             "requires": {
                 "escape-string-regexp": "^2.0.0"
@@ -5672,9 +4491,9 @@
             }
         },
         "ts-jest": {
-            "version": "26.4.1",
-            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.1.tgz",
-            "integrity": "sha512-F4aFq01aS6mnAAa0DljNmKr/Kk9y4HVZ1m6/rtJ0ED56cuxINGq3Q9eVAh+z5vcYKe5qnTMvv90vE8vUMFxomg==",
+            "version": "26.4.4",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.4.tgz",
+            "integrity": "sha512-3lFWKbLxJm34QxyVNNCgXX1u4o/RV0myvA2y2Bxm46iGIjKlaY0own9gIckbjZJPn+WaJEnfPPJ20HHGpoq4yg==",
             "dev": true,
             "requires": {
                 "@types/jest": "26.x",
@@ -5697,9 +4516,9 @@
                     "dev": true
                 },
                 "yargs-parser": {
-                    "version": "20.2.0",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.0.tgz",
-                    "integrity": "sha512-2agPoRFPoIcFzOIp6656gcvsg2ohtscpw2OINr/q46+Sq41xz2OYLqx5HRHabmFU1OARIPAYH5uteICE7mn/5A==",
+                    "version": "20.2.4",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+                    "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
                     "dev": true
                 }
             }
@@ -5750,9 +4569,9 @@
             }
         },
         "typescript": {
-            "version": "3.9.7",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-            "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+            "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
             "dev": true
         },
         "union-value": {
@@ -5829,14 +4648,14 @@
             "dev": true
         },
         "uuid": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-            "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
+            "version": "8.3.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+            "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
         },
         "v8-to-istanbul": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-5.0.1.tgz",
-            "integrity": "sha512-mbDNjuDajqYe3TXFk5qxcQy8L1msXNE37WTlLoqqpBfRsimbNcrlhQlDPntmECEcUvdC+AQ8CyMMf6EUx1r74Q==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.0.0.tgz",
+            "integrity": "sha512-fLL2rFuQpMtm9r8hrAV2apXX/WqHJ6+IC4/eQVdMDGBUgH/YMV4Gv3duk3kjmyg6uiQWBAA9nJwue4iJUOkHeA==",
             "dev": true,
             "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.1",
@@ -5922,9 +4741,9 @@
             "dev": true
         },
         "whatwg-url": {
-            "version": "8.2.2",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.2.2.tgz",
-            "integrity": "sha512-PcVnO6NiewhkmzV0qn7A+UZ9Xx4maNTI+O+TShmfE4pqjoCMwUMjkvoNhNHPTvgR7QH9Xt3R13iHuWy2sToFxQ==",
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.4.0.tgz",
+            "integrity": "sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==",
             "dev": true,
             "requires": {
                 "lodash.sortby": "^4.7.0",
@@ -5983,9 +4802,9 @@
             }
         },
         "ws": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-            "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
+            "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
             "dev": true
         },
         "xml-name-validator": {
@@ -6001,9 +4820,9 @@
             "dev": true
         },
         "y18n": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+            "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
             "dev": true
         },
         "yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "run-matlab-command-action",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,17 +21,17 @@
     "dependencies": {
         "@actions/core": "^1.2.6",
         "@actions/exec": "^1.0.4",
-        "uuid": "^8.3.0"
+        "uuid": "^8.3.1"
     },
     "devDependencies": {
-        "@types/jest": "^26.0.14",
-        "@types/node": "^14.11.2",
+        "@types/jest": "^26.0.15",
+        "@types/node": "^14.14.10",
         "@types/uuid": "^8.3.0",
         "@zeit/ncc": "^0.22.3",
-        "jest": "^26.4.2",
-        "jest-circus": "^26.4.2",
-        "prettier": "2.0.5",
-        "ts-jest": "^26.4.1",
-        "typescript": "^3.9.7"
+        "jest": "^26.6.3",
+        "jest-circus": "^26.6.3",
+        "prettier": "2.2.1",
+        "ts-jest": "^26.4.4",
+        "typescript": "^4.1.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "run-matlab-command-action",
     "author": "The MathWorks, Inc.",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "description": "",
     "main": "lib/index.js",
     "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,10 @@ async function run() {
     });
 }
 
-run().catch((e) => {
-    core.setFailed(e);
-});
+// Do not run if this node module is required by another action such as
+// run-tests.
+if (!(require.main === module)) {
+    run().catch((e) => {
+        core.setFailed(e);
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,9 +25,9 @@ async function run() {
     });
 }
 
-// Do not run if this node module is required by another action such as
-// run-tests.
-if (!(require.main === module)) {
+// Only run this action if it is invoked directly. Do not run if this node
+// module is required by another action such as run-tests.
+if (require.main === module) {
     run().catch((e) => {
         core.setFailed(e);
     });

--- a/src/matlab.ts
+++ b/src/matlab.ts
@@ -50,7 +50,7 @@ export async function generateScript(workspaceDir: string, command: string): Pro
  * @param fn ExecFn that will execute a command on the runner
  */
 export async function runCommand(hs: HelperScript, platform: string, fn: ExecFn): Promise<void> {
-    const rmcPath = getRmcPath(platform);
+    const rmcPath = getRunMATLABCommandScriptPath(platform);
     await fs.chmod(rmcPath, 0o777);
 
     const rmcArg = script.cdAndCall(hs.dir, hs.command);
@@ -66,7 +66,7 @@ export async function runCommand(hs: HelperScript, platform: string, fn: ExecFn)
  *
  * @param platform Operating system of the runner (e.g., "win32" or "linux")
  */
-export function getRmcPath(platform: string): string {
+export function getRunMATLABCommandScriptPath(platform: string): string {
     const ext = platform === "win32" ? "bat" : "sh";
     const rmcPath = path.join(__dirname, "bin", `run_matlab_command.${ext}`);
     return rmcPath;

--- a/src/matlab.unit.test.ts
+++ b/src/matlab.unit.test.ts
@@ -112,7 +112,7 @@ describe("run command", () => {
 describe("ci helper path", () => {
     const testCase = (platform: string, ext: string) => {
         it(`considers the appropriate script on ${platform}`, () => {
-            const actualPath = matlab.getRmcPath(platform);
+            const actualPath = matlab.getRunMATLABCommandScriptPath(platform);
             const actualExt = path.extname(actualPath);
             expect(actualExt).toMatch(ext);
         });


### PR DESCRIPTION
Changes include:

- Actually use an npm script purposed for ci
- Address an abbreviation that isn't really productive
- Update dependencies
- Invoking the setup-matlab action with a version
- Only run the action when called from the CLI; don't run when required (in the Node sense) by something like run-tests
  - This fixes the duplicate headers in run-tests
- Bump the version