### PR TITLE
Shorten action.yml description for marketplace

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@
 
 name: Run MATLAB Command
 description: >-
-  Execute a MATLAB script, function, or statement
+  Run MATLAB scripts, functions, and statements
 inputs:
   command:
     description: >-

--- a/action.yml
+++ b/action.yml
@@ -6,10 +6,7 @@ description: >-
 inputs:
   command:
     description: >-
-      Script, function, or statement to execute. 
-      If the value of `command` is the name of a MATLAB script or function, do
-      not specify the file extension. If you specify more than one MATLAB
-      command, use a comma or semicolon to separate the commands.
+      Script, function, or statement to execute
     required: true
 runs:
   using: node12

--- a/action.yml
+++ b/action.yml
@@ -2,13 +2,7 @@
 
 name: Run MATLAB Command
 description: >-
-  Execute a MATLAB script, function, or statement. 
-  MATLAB exits with exit code 0 if the specified script, function, or statement
-  executes successfully without error. Otherwise, MATLAB terminates with a
-  nonzero exit code, which causes the build to fail. You can use the assert or
-  error functions in the command to ensure that builds fail when necessary. When
-  you use this task, all of the required files must be on the MATLAB search
-  path.
+  Execute a MATLAB script, function, or statement
 inputs:
   command:
     description: >-


### PR DESCRIPTION
Attempting to get into the marketplace now (woooo 🥳 ). First thing they flag is our descriptions being too long (needs to be < 125 characters). So, I've just grabbed the first sentence since it's straight to the point (the magic is really all @mw-hrastega).

As for the lack of punctuation at the end: that seems to be the trend with other actions 🤔