### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           git tag -d "${{ github.event.release.tag_name }}"
           VERSION=$(npm version "${{ github.event.release.tag_name }}" --no-git-tag-version)
           echo "::set-output name=version::$VERSION"
-          git add package.json
+          git add package.json package-lock.json
           git commit -m "Bump $VERSION"
           git push origin HEAD:main
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,10 @@ jobs:
           git tag -d "${{ github.event.release.tag_name }}"
           VERSION=$(npm version "${{ github.event.release.tag_name }}" --no-git-tag-version)
           echo "::set-output name=version::$VERSION"
-
+          git add package.json
+          git commit -m "Bump $VERSION"
+          git push origin HEAD:main
+          
       # Now carry on, business as usual
       - name: Perform npm tasks
         run: npm run ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,8 @@ jobs:
         id: release_info
         run: |
           # Check for semantic versioning
+          echo "Preparing release for version $longVersion"
           longVersion="${{github.event.release.tag_name}}"
-          echo $longVersion
           [[ $longVersion == v[0-9]*.[0-9]*.[0-9]* ]]  || (echo "must follow semantic versioning" && exit 1)
           majorVersion=$(echo ${longVersion%.*.*})
           minorVersion=$(echo ${longVersion%.*})
@@ -70,8 +70,8 @@ jobs:
           git tag -f $majorVersion $commitHash
           git tag -f $minorVersion $commitHash
           
-          echo "About to push"
           # Force push the new minor version tag to overwrite the old tag remotely
+          echo "Pushing new tags"
           git push -f origin $longVersion
           git push -f origin $majorVersion
           git push -f origin $minorVersion

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           VERSION=$(npm version "${{ github.event.release.tag_name }}" --no-git-tag-version)
           echo "::set-output name=version::$VERSION"
           git add package.json package-lock.json
-          git commit -m "Bump $VERSION"
+          git commit -m "[skip ci] Bump $VERSION"
           git push origin HEAD:main
           
       # Now carry on, business as usual

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           
           # Delete the old major and minor version tags locally
           git tag -d $majorVersion || true
-          git tag -d $majorVersion || true
+          git tag -d $minorVersion || true
           
           # Make new major and minor version tags locally that point to the commit you got from the "git rev-list" above
           git tag -f $majorVersion $commitHash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,8 @@
-name: Perform a Release
+name: Publish
 
 on:
-  workflow_dispatch:
-    inputs:
-      npm-version-arg:
-        description: Argument to npm-version
-        default: minor
-        required: true
+  release:
+    types: [published, edited]
 
 jobs:
   build:
@@ -33,12 +29,9 @@ jobs:
       - name: Update package version
         id: update-package-version
         run: |
-          VERSION=$(npm version "${{ github.event.inputs.npm-version-arg }}")
+          git tag -d "${{ github.event.release.tag_name }}"
+          VERSION=$(npm version "${{ github.event.release.tag_name }}" --no-git-tag-version)
           echo "::set-output name=version::$VERSION"
-
-      # Update the branch with the new commit
-      - name: Push new version
-        run: git push
 
       # Now carry on, business as usual
       - name: Perform npm tasks
@@ -50,8 +43,12 @@ jobs:
       - name: Commit to release branch
         id: release_info
         run: |
-          # Retrieve the previously created tag
-          TAG="${{ steps.update-package-version.outputs.version }}"
+          # Check for semantic versioning
+          longVersion="${{github.event.release.tag_name}}"
+          echo $longVersion
+          [[ $longVersion == v[0-9]*.[0-9]*.[0-9]* ]]  || (echo "must follow semantic versioning" && exit 1)
+          majorVersion=$(echo ${longVersion%.*.*})
+          minorVersion=$(echo ${longVersion%.*})
 
           # Add the built artifacts. Using --force because dist/lib should be in
           # .gitignore
@@ -60,23 +57,21 @@ jobs:
           # Make the commit
           MESSAGE="Build for $(git rev-parse --short HEAD)"
           git commit --allow-empty -m "$MESSAGE"
+          git tag -f -a -m "Release $longVersion" $longVersion
 
-          # Create an annotated tag and push it to origin. Using -f to overwrite
-          # the tag that `npm version` made for us in a previous step
-          git tag -f -a -m "Release $TAG" $TAG
-          git push origin $TAG
-
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Create Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ needs.build.outputs.tag }}
-          release_name: Release ${{ needs.build.outputs.tag }}
-          draft: true
-          prerelease: false
+          # Get the commit of the tag you just released
+          commitHash=$(git rev-list -n 1 $longVersion)
+          
+          # Delete the old major and minor version tags locally
+          git tag -d $majorVersion || true
+          git tag -d $majorVersion || true
+          
+          # Make new major and minor version tags locally that point to the commit you got from the "git rev-list" above
+          git tag -f $majorVersion $commitHash
+          git tag -f $minorVersion $commitHash
+          
+          echo "About to push"
+          # Force push the new minor version tag to overwrite the old tag remotely
+          git push -f origin $longVersion
+          git push -f origin $majorVersion
+          git push -f origin $minorVersion

--- a/devel/contributing.md
+++ b/devel/contributing.md
@@ -1,0 +1,15 @@
+## Contributing
+
+Verify changes by running tests and building locally with the following command:
+
+```
+npm run ci
+```
+
+## Creating a New Release
+
+Familiarize yourself with the best practices for [releasing and maintaining GitHub actions](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions).
+
+Changes should be made on a new branch. The new branch should be merged to the main branch via a pull request. Ensure that all of the CI pipeline checks and tests have passed for your changes.
+
+After the pull request has been approved and merged to main, follow the Github process for [creating a new release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository). The release must follow semantic versioning (ex: vX.Y.Z). This will kick off a new pipeline execution, and the action will automatically be published to the GitHub Actions Marketplace if the pipeline finishes successfully. Check the [GitHub Marketplace](https://github.com/marketplace/actions/setup-matlab) and check the major version in the repository (ex: v1 for v1.0.0) to ensure that the new semantically versioned tag is available.


### PR DESCRIPTION
Curious about your thoughts. This should do the steps we're currently doing manually, but it is not in agreement with what GitHub is [recommending](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions#setting-up-github-actions-workflows), which is [this](https://github.com/JasonEtco/build-and-tag-action) third-party action.

The problem with the third-party action is it only publishes the two files `dist/index.js` and `action.yml` for releases, which is incompatible with how we put some other files in `dist`.