### PR TITLE
Sdfix

### DIFF
--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -83,4 +83,8 @@ jobs:
       - name: MATLAB sd startup option is not overwritten
         uses: ./
         with:
-          command: [~, f] = fileparts(pwd); assert(onetyone==111); assert(strcmp(f, 'subdir'));
+          command: >
+            assert(onetyone==111);
+            [~, f] = fileparts(pwd);
+            assert(strcmp(f, 'subdir'));
+          startup-options: -sd subdir

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -84,7 +84,7 @@ jobs:
         uses: ./
         with:
           command: >
-            assert(onetyone==111);
+            assert(onetyonentyone==111);
             [~, f] = fileparts(pwd);
             assert(strcmp(f, 'subdir'));
           startup-options: -sd subdir

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -74,3 +74,13 @@ jobs:
         uses: ./
         with:
           command: assert(onetyone==11, 'the variable `onetyone` was not set as expected by startup.m')
+
+      - run: |
+          mkdir subdir
+          echo 'onetyonetyone = 111' > startup.m
+        shell: bash
+
+      - name: MATLAB sd startup option is not overwritten
+        uses: ./
+        with:
+          command: [~, f] = fileparts(pwd); assert(onetyone==111); assert(strcmp(f, 'subdir'));

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -77,7 +77,7 @@ jobs:
 
       - run: |
           mkdir subdir
-          echo 'onetyonetyone = 111' > startup.m
+          echo 'onetyonetyone = 111' > subdir/startup.m
         shell: bash
 
       - name: MATLAB sd startup option is not overwritten

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -84,7 +84,7 @@ jobs:
         uses: ./
         with:
           command: >
-            assert(onetyonentyone==111);
+            assert(onetyonetyone==111);
             [~, f] = fileparts(pwd);
             assert(strcmp(f, 'subdir'));
           startup-options: -sd subdir

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -67,10 +67,10 @@ jobs:
         with:
           command: assert(isfile("mylog.log"));
       
-      - run: echo 'onetyone = 11' > startup.m
+      - run: pwd && echo 'onetyone = 11' > startup.m
         shell: bash
       
       - name: MATLAB runs startup.m automatically
         uses: ./
         with:
-          command: assert(onetyone==11, 'the variable `onetyone` was not set as expected by startup.m')
+          command: disp(pwd());assert(onetyone==11, 'the variable `onetyone` was not set as expected by startup.m')

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -67,10 +67,10 @@ jobs:
         with:
           command: assert(isfile("mylog.log"));
       
-      - run: pwd && echo 'onetyone = 11' > startup.m
+      - run: echo 'onetyone = 11' > startup.m
         shell: bash
       
       - name: MATLAB runs startup.m automatically
         uses: ./
         with:
-          command: disp(pwd());assert(onetyone==11, 'the variable `onetyone` was not set as expected by startup.m')
+          command: assert(onetyone==11, 'the variable `onetyone` was not set as expected by startup.m')

--- a/src/matlab.ts
+++ b/src/matlab.ts
@@ -33,7 +33,7 @@ export async function generateScript(workspaceDir: string, command: string): Pro
     const temporaryDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "run_matlab_command-"));
 
     const scriptPath = path.join(temporaryDirectory, scriptName + ".m");
-    await fs.writeFile(scriptPath, script.cdAndCall(workspaceDir, command), {
+    await fs.writeFile(scriptPath, script.cdAndCall(scriptName, command), {
         encoding: "utf8",
     });
 
@@ -54,7 +54,7 @@ export async function runCommand(hs: HelperScript, platform: string, architectur
     const rmcPath = getRunMATLABCommandScriptPath(platform, architecture);
     await fs.chmod(rmcPath, 0o777);
 
-    const rmcArg = script.cdAndCall(hs.dir, hs.command);
+    const rmcArg = `${hs.command}(cd('${hs.dir}'));`;
 
     let execArgs = [rmcArg];
 

--- a/src/matlab.ts
+++ b/src/matlab.ts
@@ -33,7 +33,7 @@ export async function generateScript(workspaceDir: string, command: string): Pro
     const temporaryDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "run_matlab_command-"));
 
     const scriptPath = path.join(temporaryDirectory, scriptName + ".m");
-    await fs.writeFile(scriptPath, script.cdAndCall(scriptName, command), {
+    await fs.writeFile(scriptPath, script.cdAndCall(command), {
         encoding: "utf8",
     });
 
@@ -54,7 +54,7 @@ export async function runCommand(hs: HelperScript, platform: string, architectur
     const rmcPath = getRunMATLABCommandScriptPath(platform, architecture);
     await fs.chmod(rmcPath, 0o777);
 
-    const rmcArg = `${hs.command}(cd('${hs.dir}'));`;
+    const rmcArg = `setenv("MW_ORIG_WORKING_FOLDER", cd('${hs.dir}'));${hs.command}`;
 
     let execArgs = [rmcArg];
 

--- a/src/matlab.ts
+++ b/src/matlab.ts
@@ -38,7 +38,7 @@ export async function generateScript(workspaceDir: string, command: string): Pro
     });
 
     return { 
-        dir: script.pathToCharVec(temporaryDirectory), 
+        dir: temporaryDirectory, 
         command: scriptName 
     };
 }
@@ -57,7 +57,7 @@ export async function runCommand(hs: HelperScript, platform: string, architectur
     const rmcPath = getRunMATLABCommandScriptPath(platform, architecture);
     await fs.chmod(rmcPath, 0o777);
 
-    const rmcArg = `setenv('MW_ORIG_WORKING_FOLDER', cd('${hs.dir}'));${hs.command}`;
+    const rmcArg = `setenv('MW_ORIG_WORKING_FOLDER', cd('${script.pathToCharVec(hs.dir)}'));${hs.command}`;
 
     let execArgs = [rmcArg];
 

--- a/src/matlab.ts
+++ b/src/matlab.ts
@@ -37,7 +37,10 @@ export async function generateScript(workspaceDir: string, command: string): Pro
         encoding: "utf8",
     });
 
-    return { dir: temporaryDirectory, command: scriptName };
+    return { 
+        dir: script.pathToCharVec(temporaryDirectory), 
+        command: scriptName 
+    };
 }
 
 /**
@@ -54,7 +57,7 @@ export async function runCommand(hs: HelperScript, platform: string, architectur
     const rmcPath = getRunMATLABCommandScriptPath(platform, architecture);
     await fs.chmod(rmcPath, 0o777);
 
-    const rmcArg = `setenv("MW_ORIG_WORKING_FOLDER", cd('${hs.dir}'));${hs.command}`;
+    const rmcArg = `setenv('MW_ORIG_WORKING_FOLDER', cd('${hs.dir}'));${hs.command}`;
 
     let execArgs = [rmcArg];
 

--- a/src/script.ts
+++ b/src/script.ts
@@ -1,4 +1,4 @@
-// Copyright 2020 The MathWorks, Inc.
+// Copyright 2020-2023 The MathWorks, Inc.
 
 /**
  * Generate MATLAB command for changing directories and calling a command in it.
@@ -7,8 +7,8 @@
  * @param command Command to run in directory.
  * @returns MATLAB command.
  */
-export function cdAndCall(dir: string, command: string): string {
-    return `cd('${pathToCharVec(dir)}');${command}`;
+export function cdAndCall(scriptName: string, command: string): string {
+    return `function ${scriptName}(folder)\ncd(folder);${command}`;
 }
 
 /**

--- a/src/script.ts
+++ b/src/script.ts
@@ -8,7 +8,7 @@
  * @returns MATLAB command.
  */
 export function cdAndCall(command: string): string {
-    return `cd(getenv("MW_ORIG_WORKING_FOLDER"));${command}`;
+    return `cd(getenv('MW_ORIG_WORKING_FOLDER'));${command}`;
 }
 
 /**

--- a/src/script.ts
+++ b/src/script.ts
@@ -7,8 +7,8 @@
  * @param command Command to run in directory.
  * @returns MATLAB command.
  */
-export function cdAndCall(scriptName: string, command: string): string {
-    return `function ${scriptName}(folder)\ncd(folder);${command}`;
+export function cdAndCall(command: string): string {
+    return `cd(getenv("MW_ORIG_WORKING_FOLDER"));${command}`;
 }
 
 /**

--- a/src/script.unit.test.ts
+++ b/src/script.unit.test.ts
@@ -5,11 +5,10 @@ import * as script from "./script";
 describe("call generation", () => {
     it("ideally works", () => {
         // I know what your thinking
-        const testName = "command_uuid_123";
         const testCommand = "disp('hello world')";
-        const expectedString = `function command_uuid_123(folder)\ncd(folder);${testCommand}`;
+        const expectedString = `cd(getenv("MW_ORIG_WORKING_FOLDER"));${testCommand}`;
 
-        expect(script.cdAndCall(testName, testCommand)).toMatch(expectedString);
+        expect(script.cdAndCall(testCommand)).toMatch(expectedString);
     });
 });
 

--- a/src/script.unit.test.ts
+++ b/src/script.unit.test.ts
@@ -1,15 +1,15 @@
-// Copyright 2020 The MathWorks, Inc.
+// Copyright 2020-2023 The MathWorks, Inc.
 
 import * as script from "./script";
 
 describe("call generation", () => {
     it("ideally works", () => {
         // I know what your thinking
-        const testDir = String.raw`C:\Users\you\You're Documents`;
+        const testName = "command_uuid_123";
         const testCommand = "disp('hello world')";
-        const expectedString = String.raw`cd('C:\Users\you\You''re Documents');${testCommand}`;
+        const expectedString = `function command_uuid_123(folder)\ncd(folder);${testCommand}`;
 
-        expect(script.cdAndCall(testDir, testCommand)).toMatch(expectedString);
+        expect(script.cdAndCall(testName, testCommand)).toMatch(expectedString);
     });
 });
 

--- a/src/script.unit.test.ts
+++ b/src/script.unit.test.ts
@@ -6,7 +6,7 @@ describe("call generation", () => {
     it("ideally works", () => {
         // I know what your thinking
         const testCommand = "disp('hello world')";
-        const expectedString = `cd(getenv("MW_ORIG_WORKING_FOLDER"));${testCommand}`;
+        const expectedString = `cd(getenv('MW_ORIG_WORKING_FOLDER'));${testCommand}`;
 
         expect(script.cdAndCall(testCommand)).toMatch(expectedString);
     });


### PR DESCRIPTION
Fix for the `-sd` option using an environment variable. Because it changes the function signature of `cdAndCall`, run-build and run-tests will need to be updated in parallel.

EDIT: Even better it looks like I remembered incorrectly and the other two actions don't directly call `cdAndCall`