### PR TITLE
Remove log message about generating script

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@ async function run() {
 
     const helperScript = await core.group("Generate script", async () => {
         const helperScript = await matlab.generateScript(workspaceDir, command);
-        core.info("Successfully generated script");
         return helperScript;
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,14 +16,8 @@ async function run() {
     const command = core.getInput("command");
     const startupOpts = core.getInput("startup-options").split(" ");
 
-    const helperScript = await core.group("Generate script", async () => {
-        const helperScript = await matlab.generateScript(workspaceDir, command);
-        return helperScript;
-    });
-
-    await core.group("Run command", async () => {
-        await matlab.runCommand(helperScript, platform, architecture, exec.exec, startupOpts);
-    });
+    const helperScript = await matlab.generateScript(workspaceDir, command);
+    await matlab.runCommand(helperScript, platform, architecture, exec.exec, startupOpts);
 }
 
 // Only run this action if it is invoked directly. Do not run if this node


### PR DESCRIPTION
Remove "Successfully generated script" message from the log. This is an implementation detail and clutters up the logs of our other actions.