### PR TITLE
Improve readability of generated script

### DIFF
--- a/src/matlab.ts
+++ b/src/matlab.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 The MathWorks, Inc.
+// Copyright 2020-2025 The MathWorks, Inc.
 
 import { promises as fs } from "fs";
 import * as os from "os";

--- a/src/script.ts
+++ b/src/script.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 The MathWorks, Inc.
+// Copyright 2020-2025 The MathWorks, Inc.
 
 /**
  * Generate MATLAB command for changing directories and calling a command in it.
@@ -8,7 +8,7 @@
  * @returns MATLAB command.
  */
 export function cdAndCall(command: string): string {
-    return `cd(getenv('MW_ORIG_WORKING_FOLDER'));${command}`;
+    return `cd(getenv('MW_ORIG_WORKING_FOLDER')); ${command}`;
 }
 
 /**

--- a/src/script.unit.test.ts
+++ b/src/script.unit.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 The MathWorks, Inc.
+// Copyright 2020-2025 The MathWorks, Inc.
 
 import * as script from "./script";
 
@@ -6,7 +6,7 @@ describe("call generation", () => {
     it("ideally works", () => {
         // I know what your thinking
         const testCommand = "disp('hello world')";
-        const expectedString = `cd(getenv('MW_ORIG_WORKING_FOLDER'));${testCommand}`;
+        const expectedString = `cd(getenv('MW_ORIG_WORKING_FOLDER')); ${testCommand}`;
 
         expect(script.cdAndCall(testCommand)).toMatch(expectedString);
     });


### PR DESCRIPTION
Adding a space between the `cd` and the command in the generated script so that things are more readable when something fails. At the moment it is all crammed together and hard to distinguish where one statement ends and the next begins.

<img width="909" alt="Screenshot 2025-04-07 at 2 11 51 PM" src="https://github.com/user-attachments/assets/71ba394f-41ac-4bab-bc0e-4d3fb508baf6" />