### PR TITLE
Add generate-job-summary input to control CI job summary generation

### DIFF
--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -94,6 +94,14 @@ jobs:
             [~, f] = fileparts(pwd);
             assert(strcmp(f, 'subdir'));
           startup-options: -sd subdir
+      - name: Run command to run tests
+        uses: ./
+        with:
+          command: runtests("sample/TheTruth.m");
+      - name: Run command to run tests (sanity check for test summary)
+        uses: ./
+        with:
+          command: runtests("sample/TheTruth.m"); runtests("sample/TheTruth.m"); runtests("sample/TheTruth.m");
       - name: Create buildfile.m in project root for build and test summary
         shell: bash
         run: |
@@ -111,6 +119,10 @@ jobs:
         uses: ./
         with:
           command: buildtool preMadeTest
+      - name: Run command with buildtool multiple times with pre-made test task (sanity check for build summary)
+        uses: ./
+        with:
+          command: buildtool preMadeTest; buildtool preMadeTest; buildtool preMadeTest;
       - name: Verify environment variables make it to MATLAB
         uses: ./
         with:

--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -119,10 +119,6 @@ jobs:
         uses: ./
         with:
           command: buildtool preMadeTest
-      - name: Run command with buildtool multiple times with pre-made test task (sanity check for build summary)
-        uses: ./
-        with:
-          command: buildtool preMadeTest; buildtool preMadeTest; buildtool preMadeTest;
       - name: Verify environment variables make it to MATLAB
         uses: ./
         with:

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,11 @@ inputs:
       Startup options for MATLAB
     required: false
     default: ""
+  generate-job-summary:
+    description: >-
+      Whether to generate a job summary with test results and code coverage information
+    required: false
+    default: true
 runs:
   using: node24
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
       Startup options for MATLAB
     required: false
     default: ""
-  generate-job-summary:
+  generate-summary:
     description: >-
       Whether to generate a MATLAB-related job summary for the workflow run
     required: false

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     default: ""
   generate-summary:
     description: >-
-      Whether to generate a MATLAB-related job summary for the workflow run
+      Option to generate a summary for the GitHub job summary
     required: false
     default: true
 runs:

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     default: ""
   generate-job-summary:
     description: >-
-      Whether to generate a job summary with test results and code coverage information
+      Whether to generate a MATLAB-related job summary for the workflow run
     required: false
     default: true
 runs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1269,9 +1269,9 @@
             "license": "MIT"
         },
         "node_modules/@ungap/structured-clone": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-            "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+            "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
             "dev": true,
             "license": "ISC"
         },
@@ -1883,9 +1883,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001791",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-            "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+            "version": "1.0.30001792",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+            "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
             "dev": true,
             "funding": [
                 {
@@ -2071,7 +2071,7 @@
         },
         "node_modules/common-utils": {
             "version": "2.3.0",
-            "resolved": "git+ssh://git@github.com/matlab-actions/common-utils.git#2d9ace4eed6057ceddb027a33924b568fd4e2f5f",
+            "resolved": "git+ssh://git@github.com/matlab-actions/common-utils.git#a6060ff5a3c42b339fc61368248212e22b6035e6",
             "dependencies": {
                 "@actions/core": "^3.0.0",
                 "@actions/exec": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@actions/core": "^3.0.0",
                 "@actions/exec": "^3.0.0",
-                "common-utils": "github:matlab-actions/common-utils#v2.3.0"
+                "common-utils": "github:matlab-actions/common-utils#v2.3.1"
             },
             "devDependencies": {
                 "@types/jest": "^30.0.0",
@@ -659,17 +659,17 @@
             }
         },
         "node_modules/@jest/console": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.3.0.tgz",
-            "integrity": "sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
+            "integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/types": "30.3.0",
+                "@jest/types": "30.4.1",
                 "@types/node": "*",
                 "chalk": "^4.1.2",
-                "jest-message-util": "30.3.0",
-                "jest-util": "30.3.0",
+                "jest-message-util": "30.4.1",
+                "jest-util": "30.4.1",
                 "slash": "^3.0.0"
             },
             "engines": {
@@ -677,38 +677,39 @@
             }
         },
         "node_modules/@jest/core": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.3.0.tgz",
-            "integrity": "sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==",
+            "version": "30.4.2",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
+            "integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/console": "30.3.0",
-                "@jest/pattern": "30.0.1",
-                "@jest/reporters": "30.3.0",
-                "@jest/test-result": "30.3.0",
-                "@jest/transform": "30.3.0",
-                "@jest/types": "30.3.0",
+                "@jest/console": "30.4.1",
+                "@jest/pattern": "30.4.0",
+                "@jest/reporters": "30.4.1",
+                "@jest/test-result": "30.4.1",
+                "@jest/transform": "30.4.1",
+                "@jest/types": "30.4.1",
                 "@types/node": "*",
                 "ansi-escapes": "^4.3.2",
                 "chalk": "^4.1.2",
                 "ci-info": "^4.2.0",
                 "exit-x": "^0.2.2",
+                "fast-json-stable-stringify": "^2.1.0",
                 "graceful-fs": "^4.2.11",
-                "jest-changed-files": "30.3.0",
-                "jest-config": "30.3.0",
-                "jest-haste-map": "30.3.0",
-                "jest-message-util": "30.3.0",
-                "jest-regex-util": "30.0.1",
-                "jest-resolve": "30.3.0",
-                "jest-resolve-dependencies": "30.3.0",
-                "jest-runner": "30.3.0",
-                "jest-runtime": "30.3.0",
-                "jest-snapshot": "30.3.0",
-                "jest-util": "30.3.0",
-                "jest-validate": "30.3.0",
-                "jest-watcher": "30.3.0",
-                "pretty-format": "30.3.0",
+                "jest-changed-files": "30.4.1",
+                "jest-config": "30.4.2",
+                "jest-haste-map": "30.4.1",
+                "jest-message-util": "30.4.1",
+                "jest-regex-util": "30.4.0",
+                "jest-resolve": "30.4.1",
+                "jest-resolve-dependencies": "30.4.2",
+                "jest-runner": "30.4.2",
+                "jest-runtime": "30.4.2",
+                "jest-snapshot": "30.4.1",
+                "jest-util": "30.4.1",
+                "jest-validate": "30.4.1",
+                "jest-watcher": "30.4.1",
+                "pretty-format": "30.4.1",
                 "slash": "^3.0.0"
             },
             "engines": {
@@ -724,9 +725,9 @@
             }
         },
         "node_modules/@jest/diff-sequences": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
-            "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+            "version": "30.4.0",
+            "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+            "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -734,39 +735,39 @@
             }
         },
         "node_modules/@jest/environment": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
-            "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+            "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/fake-timers": "30.3.0",
-                "@jest/types": "30.3.0",
+                "@jest/fake-timers": "30.4.1",
+                "@jest/types": "30.4.1",
                 "@types/node": "*",
-                "jest-mock": "30.3.0"
+                "jest-mock": "30.4.1"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/@jest/expect": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
-            "integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
+            "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "expect": "30.3.0",
-                "jest-snapshot": "30.3.0"
+                "expect": "30.4.1",
+                "jest-snapshot": "30.4.1"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/@jest/expect-utils": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
-            "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+            "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -777,18 +778,18 @@
             }
         },
         "node_modules/@jest/fake-timers": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
-            "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+            "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/types": "30.3.0",
-                "@sinonjs/fake-timers": "^15.0.0",
+                "@jest/types": "30.4.1",
+                "@sinonjs/fake-timers": "^15.4.0",
                 "@types/node": "*",
-                "jest-message-util": "30.3.0",
-                "jest-mock": "30.3.0",
-                "jest-util": "30.3.0"
+                "jest-message-util": "30.4.1",
+                "jest-mock": "30.4.1",
+                "jest-util": "30.4.1"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -805,47 +806,47 @@
             }
         },
         "node_modules/@jest/globals": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz",
-            "integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
+            "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/environment": "30.3.0",
-                "@jest/expect": "30.3.0",
-                "@jest/types": "30.3.0",
-                "jest-mock": "30.3.0"
+                "@jest/environment": "30.4.1",
+                "@jest/expect": "30.4.1",
+                "@jest/types": "30.4.1",
+                "jest-mock": "30.4.1"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/@jest/pattern": {
-            "version": "30.0.1",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
-            "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+            "version": "30.4.0",
+            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
-                "jest-regex-util": "30.0.1"
+                "jest-regex-util": "30.4.0"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/@jest/reporters": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.3.0.tgz",
-            "integrity": "sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
+            "integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@bcoe/v8-coverage": "^0.2.3",
-                "@jest/console": "30.3.0",
-                "@jest/test-result": "30.3.0",
-                "@jest/transform": "30.3.0",
-                "@jest/types": "30.3.0",
+                "@jest/console": "30.4.1",
+                "@jest/test-result": "30.4.1",
+                "@jest/transform": "30.4.1",
+                "@jest/types": "30.4.1",
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "@types/node": "*",
                 "chalk": "^4.1.2",
@@ -858,9 +859,9 @@
                 "istanbul-lib-report": "^3.0.0",
                 "istanbul-lib-source-maps": "^5.0.0",
                 "istanbul-reports": "^3.1.3",
-                "jest-message-util": "30.3.0",
-                "jest-util": "30.3.0",
-                "jest-worker": "30.3.0",
+                "jest-message-util": "30.4.1",
+                "jest-util": "30.4.1",
+                "jest-worker": "30.4.1",
                 "slash": "^3.0.0",
                 "string-length": "^4.0.2",
                 "v8-to-istanbul": "^9.0.1"
@@ -878,9 +879,9 @@
             }
         },
         "node_modules/@jest/schemas": {
-            "version": "30.0.5",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
-            "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -891,13 +892,13 @@
             }
         },
         "node_modules/@jest/snapshot-utils": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
-            "integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+            "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/types": "30.3.0",
+                "@jest/types": "30.4.1",
                 "chalk": "^4.1.2",
                 "graceful-fs": "^4.2.11",
                 "natural-compare": "^1.4.0"
@@ -922,14 +923,14 @@
             }
         },
         "node_modules/@jest/test-result": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.3.0.tgz",
-            "integrity": "sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
+            "integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/console": "30.3.0",
-                "@jest/types": "30.3.0",
+                "@jest/console": "30.4.1",
+                "@jest/types": "30.4.1",
                 "@types/istanbul-lib-coverage": "^2.0.6",
                 "collect-v8-coverage": "^1.0.2"
             },
@@ -938,15 +939,15 @@
             }
         },
         "node_modules/@jest/test-sequencer": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.3.0.tgz",
-            "integrity": "sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
+            "integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/test-result": "30.3.0",
+                "@jest/test-result": "30.4.1",
                 "graceful-fs": "^4.2.11",
-                "jest-haste-map": "30.3.0",
+                "jest-haste-map": "30.4.1",
                 "slash": "^3.0.0"
             },
             "engines": {
@@ -954,23 +955,23 @@
             }
         },
         "node_modules/@jest/transform": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
-            "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+            "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.27.4",
-                "@jest/types": "30.3.0",
+                "@jest/types": "30.4.1",
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "babel-plugin-istanbul": "^7.0.1",
                 "chalk": "^4.1.2",
                 "convert-source-map": "^2.0.0",
                 "fast-json-stable-stringify": "^2.1.0",
                 "graceful-fs": "^4.2.11",
-                "jest-haste-map": "30.3.0",
-                "jest-regex-util": "30.0.1",
-                "jest-util": "30.3.0",
+                "jest-haste-map": "30.4.1",
+                "jest-regex-util": "30.4.0",
+                "jest-util": "30.4.1",
                 "pirates": "^4.0.7",
                 "slash": "^3.0.0",
                 "write-file-atomic": "^5.0.1"
@@ -980,14 +981,14 @@
             }
         },
         "node_modules/@jest/types": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-            "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/pattern": "30.0.1",
-                "@jest/schemas": "30.0.5",
+                "@jest/pattern": "30.4.0",
+                "@jest/schemas": "30.4.1",
                 "@types/istanbul-lib-coverage": "^2.0.6",
                 "@types/istanbul-reports": "^3.0.4",
                 "@types/node": "*",
@@ -1049,16 +1050,22 @@
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "0.2.12",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-            "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "^1.4.3",
-                "@emnapi/runtime": "^1.4.3",
-                "@tybys/wasm-util": "^0.10.0"
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
             }
         },
         "node_modules/@pkgjs/parseargs": {
@@ -1235,9 +1242,9 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "24.12.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-            "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+            "version": "24.12.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+            "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1276,9 +1283,9 @@
             "license": "ISC"
         },
         "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-            "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.0.tgz",
+            "integrity": "sha512-FmIJ5Bq2UUrpj2TrJiOvtfvgh98QqB3PKVqWrHp0SrYqlNSlch4YXToiiNK+mSTNFes07DipzT/JpJIq8xsOrg==",
             "cpu": [
                 "arm"
             ],
@@ -1290,9 +1297,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-android-arm64": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-            "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.0.tgz",
+            "integrity": "sha512-XqE7sTuM4wquiiSptDC18/7SRh5LOQhmjRgu7j65T+m7lP0FzJQl0fSL+Zd7aATVJciVpcNkk0ml4hMwASvfXQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1304,9 +1311,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-darwin-arm64": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
-            "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.0.tgz",
+            "integrity": "sha512-7aOfLOGYIh3Whvzv6fi3bA9aj8tuf7XDYbzTtsMeXixdRGLT6luR1htBSbjvWXyCn4TbKgz5SDa5gURYdlM0GQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1318,9 +1325,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-darwin-x64": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-            "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.0.tgz",
+            "integrity": "sha512-2NiHBibXXDCBnjpzpwHoq4Fs6kvt9QYD6ravNA3D8KQaKr7r0qu6CyvqJfDLYssijCSs2UwEmkKcAmCxP/HOXA==",
             "cpu": [
                 "x64"
             ],
@@ -1332,9 +1339,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-freebsd-x64": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-            "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.0.tgz",
+            "integrity": "sha512-x/k1Vy1QoDrOYLJzQg2/WsRGQPS0Saw4basKqjZDQlPdkSApsvDdB9h8oRQDUTJCCazSlqLm+Ry9NQFlJicacQ==",
             "cpu": [
                 "x64"
             ],
@@ -1346,9 +1353,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-            "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.0.tgz",
+            "integrity": "sha512-zuHruxqemJqM2lrVwIgw7o3/0rLrskWDqVRAc8974nNy3cZR2N9cfatIE5PzmSNeRSafh0rAaS3ev294yCyj7A==",
             "cpu": [
                 "arm"
             ],
@@ -1360,9 +1367,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-            "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.0.tgz",
+            "integrity": "sha512-s2WgKQXQXhV14OT3jNoS1jN4c+8Mvamxq6jG3L7Igl8teXaGZvjI3RfZksqoxL3UAEin9UkZSApXZ+shocI1ZQ==",
             "cpu": [
                 "arm"
             ],
@@ -1374,9 +1381,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-            "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.0.tgz",
+            "integrity": "sha512-ghMWlxxa3aCW9sk5FpzrTXSo/NSanKs/RovDal5q+T2Q+dAKLFyGXWmQ6AAMsl6k/TgXHw+jj9Q9sELLx9mfJw==",
             "cpu": [
                 "arm64"
             ],
@@ -1388,9 +1395,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-            "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.0.tgz",
+            "integrity": "sha512-ldOaKTzXNIHjGzRtzgfh+g6mqt30Q8hnR+EFdfeKYgeuMqnwsllk6IaN2kadvuRRQNBr1ycI45pmgGA5EUxzuA==",
             "cpu": [
                 "arm64"
             ],
@@ -1402,9 +1409,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-            "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.0.tgz",
+            "integrity": "sha512-PQRjWSz5v+7K9CHh8a11t6JHfmuG2o3ozHgj/9IsEtSMBc/S8p8eZoJO0+i7FUq0JEjnIfLRLUADXOF/2jx4SQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -1416,9 +1423,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-            "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.0.tgz",
+            "integrity": "sha512-slpQUuAp3+I0jsFyHxBaqETZSe8+OaG019nDOCBD0ZqZSNv0z7lMXKDgpH9BsSD+1Z5BSvV1QUbWS/MbGxpI+A==",
             "cpu": [
                 "riscv64"
             ],
@@ -1430,9 +1437,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-            "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.0.tgz",
+            "integrity": "sha512-v30e31aTFDfl1R+On53cNpd4sMQ+lzYTE4dxVia1B++Ds+27lEZSOlwjPfPN20mxb9ENis1mwUW+5SO6OzXJcA==",
             "cpu": [
                 "riscv64"
             ],
@@ -1444,9 +1451,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-            "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.0.tgz",
+            "integrity": "sha512-yn6cnDhoH1IOgYvLnTeu7iAf1iknc7SXjqyLPCr3umbaeuFD8Uy2x3c3F82x2SDVEX/JpEkAGNd18lUBw4w9aQ==",
             "cpu": [
                 "s390x"
             ],
@@ -1458,9 +1465,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
-            "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.0.tgz",
+            "integrity": "sha512-M0zUTXIoRbPdWmLOs8hG3CnLVKTMbcAkC1++GJzjLAlGfH5gvhbePa6+TFniTgqiizGr0/3fdXI7R8aNwy/N4g==",
             "cpu": [
                 "x64"
             ],
@@ -1472,9 +1479,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
-            "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.0.tgz",
+            "integrity": "sha512-GJUwROe22qValEd7JRT7FG/u36Iv/IL9AedRw7pEdbc8KcfbODcygvQHAVigBFReylyLe8UkPYxJy7F5Sm+Ldw==",
             "cpu": [
                 "x64"
             ],
@@ -1485,10 +1492,24 @@
                 "linux"
             ]
         },
+        "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.0.tgz",
+            "integrity": "sha512-UwIkgOapYxrSPf8KTOtXeZKJD69upM9hQQuty1W0wQAJwsZrJSXFEoxuJ6lcjmEp/iJvx5PUknMqqBXJlzPTyw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
         "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-            "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.0.tgz",
+            "integrity": "sha512-hE7r1jGIYXTR+inEZxKpUUT+P44RS/J5fz6x5UVvLjVsmHlkpeHOetRs5eglgoPskXwfROZlChCWBq+UoS+6Qg==",
             "cpu": [
                 "wasm32"
             ],
@@ -1496,16 +1517,18 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@napi-rs/wasm-runtime": "^0.2.11"
+                "@emnapi/core": "1.10.0",
+                "@emnapi/runtime": "1.10.0",
+                "@napi-rs/wasm-runtime": "^1.1.4"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-            "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.0.tgz",
+            "integrity": "sha512-zkwy74gxj0z6G6KxCaVsQJQDlLs8g3sUYtNJYrmThB0GHsK7cmCFtRLLqaeFUvf+K2lWG8KXv1PpQr18NgNOWw==",
             "cpu": [
                 "arm64"
             ],
@@ -1517,9 +1540,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-            "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.0.tgz",
+            "integrity": "sha512-dDLr9aigi1kz+sjL9o/TSVe+5Xf5zjSrXlSJALCJE2hY/J2Ml1qKxmFZYJVEWvp72hRjIxnHH83o0cPXLkJqiA==",
             "cpu": [
                 "ia32"
             ],
@@ -1531,9 +1554,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-            "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.0.tgz",
+            "integrity": "sha512-xLJGnOAnh4eYwZLoPW27FsCAI1zwgXpeOsxUUYRNjbSmEip5j4B8fPazsoicTN+YcaAET64JyuMvazxZUe/Wzg==",
             "cpu": [
                 "x64"
             ],
@@ -1670,16 +1693,16 @@
             }
         },
         "node_modules/babel-jest": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
-            "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+            "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/transform": "30.3.0",
+                "@jest/transform": "30.4.1",
                 "@types/babel__core": "^7.20.5",
                 "babel-plugin-istanbul": "^7.0.1",
-                "babel-preset-jest": "30.3.0",
+                "babel-preset-jest": "30.4.0",
                 "chalk": "^4.1.2",
                 "graceful-fs": "^4.2.11",
                 "slash": "^3.0.0"
@@ -1712,9 +1735,9 @@
             }
         },
         "node_modules/babel-plugin-jest-hoist": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz",
-            "integrity": "sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==",
+            "version": "30.4.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+            "integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1752,13 +1775,13 @@
             }
         },
         "node_modules/babel-preset-jest": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz",
-            "integrity": "sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==",
+            "version": "30.4.0",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+            "integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "babel-plugin-jest-hoist": "30.3.0",
+                "babel-plugin-jest-hoist": "30.4.0",
                 "babel-preset-current-node-syntax": "^1.2.0"
             },
             "engines": {
@@ -1776,9 +1799,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.27",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
-            "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
+            "version": "2.10.31",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
+            "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -1883,9 +1906,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001792",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-            "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+            "version": "1.0.30001793",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+            "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
             "dev": true,
             "funding": [
                 {
@@ -2070,8 +2093,8 @@
             "license": "MIT"
         },
         "node_modules/common-utils": {
-            "version": "2.3.0",
-            "resolved": "git+ssh://git@github.com/matlab-actions/common-utils.git#a6060ff5a3c42b339fc61368248212e22b6035e6",
+            "version": "2.3.1",
+            "resolved": "git+ssh://git@github.com/matlab-actions/common-utils.git#cefe8e093d1289f9bdf241a8e31af1ff5bb5e67a",
             "dependencies": {
                 "@actions/core": "^3.0.0",
                 "@actions/exec": "^3.0.0",
@@ -2185,9 +2208,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.351",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.351.tgz",
-            "integrity": "sha512-9D7Iqx8RImSvCnOsj86rCH6eQjZFQoM04Jn6HnZVM0Nu/G58/gmKYQ1d12MZTbjQbQSTGI8nwEy07ErsA2slLA==",
+            "version": "1.5.358",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.358.tgz",
+            "integrity": "sha512-EO7tKm3QxRqTs1lSuPXzl6yRAwznehp0AH9OoMOIC+4mQzTFday8FJCO5KU6J/TFSQXEOahNq4vTKpz1jmCVOA==",
             "dev": true,
             "license": "ISC"
         },
@@ -2297,18 +2320,18 @@
             }
         },
         "node_modules/expect": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
-            "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+            "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/expect-utils": "30.3.0",
+                "@jest/expect-utils": "30.4.1",
                 "@jest/get-type": "30.1.0",
-                "jest-matcher-utils": "30.3.0",
-                "jest-message-util": "30.3.0",
-                "jest-mock": "30.3.0",
-                "jest-util": "30.3.0"
+                "jest-matcher-utils": "30.4.1",
+                "jest-message-util": "30.4.1",
+                "jest-mock": "30.4.1",
+                "jest-util": "30.4.1"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -2629,9 +2652,9 @@
             }
         },
         "node_modules/istanbul-lib-instrument/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -2702,16 +2725,16 @@
             }
         },
         "node_modules/jest": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
-            "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
+            "version": "30.4.2",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
+            "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/core": "30.3.0",
-                "@jest/types": "30.3.0",
+                "@jest/core": "30.4.2",
+                "@jest/types": "30.4.1",
                 "import-local": "^3.2.0",
-                "jest-cli": "30.3.0"
+                "jest-cli": "30.4.2"
             },
             "bin": {
                 "jest": "bin/jest.js"
@@ -2729,14 +2752,14 @@
             }
         },
         "node_modules/jest-changed-files": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.3.0.tgz",
-            "integrity": "sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
+            "integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "execa": "^5.1.1",
-                "jest-util": "30.3.0",
+                "jest-util": "30.4.1",
                 "p-limit": "^3.1.0"
             },
             "engines": {
@@ -2744,29 +2767,29 @@
             }
         },
         "node_modules/jest-circus": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.3.0.tgz",
-            "integrity": "sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==",
+            "version": "30.4.2",
+            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
+            "integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/environment": "30.3.0",
-                "@jest/expect": "30.3.0",
-                "@jest/test-result": "30.3.0",
-                "@jest/types": "30.3.0",
+                "@jest/environment": "30.4.1",
+                "@jest/expect": "30.4.1",
+                "@jest/test-result": "30.4.1",
+                "@jest/types": "30.4.1",
                 "@types/node": "*",
                 "chalk": "^4.1.2",
                 "co": "^4.6.0",
                 "dedent": "^1.6.0",
                 "is-generator-fn": "^2.1.0",
-                "jest-each": "30.3.0",
-                "jest-matcher-utils": "30.3.0",
-                "jest-message-util": "30.3.0",
-                "jest-runtime": "30.3.0",
-                "jest-snapshot": "30.3.0",
-                "jest-util": "30.3.0",
+                "jest-each": "30.4.1",
+                "jest-matcher-utils": "30.4.1",
+                "jest-message-util": "30.4.1",
+                "jest-runtime": "30.4.2",
+                "jest-snapshot": "30.4.1",
+                "jest-util": "30.4.1",
                 "p-limit": "^3.1.0",
-                "pretty-format": "30.3.0",
+                "pretty-format": "30.4.1",
                 "pure-rand": "^7.0.0",
                 "slash": "^3.0.0",
                 "stack-utils": "^2.0.6"
@@ -2776,21 +2799,21 @@
             }
         },
         "node_modules/jest-cli": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.3.0.tgz",
-            "integrity": "sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==",
+            "version": "30.4.2",
+            "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
+            "integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/core": "30.3.0",
-                "@jest/test-result": "30.3.0",
-                "@jest/types": "30.3.0",
+                "@jest/core": "30.4.2",
+                "@jest/test-result": "30.4.1",
+                "@jest/types": "30.4.1",
                 "chalk": "^4.1.2",
                 "exit-x": "^0.2.2",
                 "import-local": "^3.2.0",
-                "jest-config": "30.3.0",
-                "jest-util": "30.3.0",
-                "jest-validate": "30.3.0",
+                "jest-config": "30.4.2",
+                "jest-util": "30.4.1",
+                "jest-validate": "30.4.1",
                 "yargs": "^17.7.2"
             },
             "bin": {
@@ -2809,33 +2832,33 @@
             }
         },
         "node_modules/jest-config": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.3.0.tgz",
-            "integrity": "sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==",
+            "version": "30.4.2",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+            "integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.27.4",
                 "@jest/get-type": "30.1.0",
-                "@jest/pattern": "30.0.1",
-                "@jest/test-sequencer": "30.3.0",
-                "@jest/types": "30.3.0",
-                "babel-jest": "30.3.0",
+                "@jest/pattern": "30.4.0",
+                "@jest/test-sequencer": "30.4.1",
+                "@jest/types": "30.4.1",
+                "babel-jest": "30.4.1",
                 "chalk": "^4.1.2",
                 "ci-info": "^4.2.0",
                 "deepmerge": "^4.3.1",
                 "glob": "^10.5.0",
                 "graceful-fs": "^4.2.11",
-                "jest-circus": "30.3.0",
-                "jest-docblock": "30.2.0",
-                "jest-environment-node": "30.3.0",
-                "jest-regex-util": "30.0.1",
-                "jest-resolve": "30.3.0",
-                "jest-runner": "30.3.0",
-                "jest-util": "30.3.0",
-                "jest-validate": "30.3.0",
+                "jest-circus": "30.4.2",
+                "jest-docblock": "30.4.0",
+                "jest-environment-node": "30.4.1",
+                "jest-regex-util": "30.4.0",
+                "jest-resolve": "30.4.1",
+                "jest-runner": "30.4.2",
+                "jest-util": "30.4.1",
+                "jest-validate": "30.4.1",
                 "parse-json": "^5.2.0",
-                "pretty-format": "30.3.0",
+                "pretty-format": "30.4.1",
                 "slash": "^3.0.0",
                 "strip-json-comments": "^3.1.1"
             },
@@ -2860,25 +2883,25 @@
             }
         },
         "node_modules/jest-diff": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
-            "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+            "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/diff-sequences": "30.3.0",
+                "@jest/diff-sequences": "30.4.0",
                 "@jest/get-type": "30.1.0",
                 "chalk": "^4.1.2",
-                "pretty-format": "30.3.0"
+                "pretty-format": "30.4.1"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/jest-docblock": {
-            "version": "30.2.0",
-            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
-            "integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
+            "version": "30.4.0",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
+            "integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2889,56 +2912,56 @@
             }
         },
         "node_modules/jest-each": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.3.0.tgz",
-            "integrity": "sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
+            "integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jest/get-type": "30.1.0",
-                "@jest/types": "30.3.0",
+                "@jest/types": "30.4.1",
                 "chalk": "^4.1.2",
-                "jest-util": "30.3.0",
-                "pretty-format": "30.3.0"
+                "jest-util": "30.4.1",
+                "pretty-format": "30.4.1"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/jest-environment-node": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.3.0.tgz",
-            "integrity": "sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
+            "integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/environment": "30.3.0",
-                "@jest/fake-timers": "30.3.0",
-                "@jest/types": "30.3.0",
+                "@jest/environment": "30.4.1",
+                "@jest/fake-timers": "30.4.1",
+                "@jest/types": "30.4.1",
                 "@types/node": "*",
-                "jest-mock": "30.3.0",
-                "jest-util": "30.3.0",
-                "jest-validate": "30.3.0"
+                "jest-mock": "30.4.1",
+                "jest-util": "30.4.1",
+                "jest-validate": "30.4.1"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/jest-haste-map": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
-            "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+            "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/types": "30.3.0",
+                "@jest/types": "30.4.1",
                 "@types/node": "*",
                 "anymatch": "^3.1.3",
                 "fb-watchman": "^2.0.2",
                 "graceful-fs": "^4.2.11",
-                "jest-regex-util": "30.0.1",
-                "jest-util": "30.3.0",
-                "jest-worker": "30.3.0",
+                "jest-regex-util": "30.4.0",
+                "jest-util": "30.4.1",
+                "jest-worker": "30.4.1",
                 "picomatch": "^4.0.3",
                 "walker": "^1.0.8"
             },
@@ -2950,49 +2973,50 @@
             }
         },
         "node_modules/jest-leak-detector": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz",
-            "integrity": "sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
+            "integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jest/get-type": "30.1.0",
-                "pretty-format": "30.3.0"
+                "pretty-format": "30.4.1"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/jest-matcher-utils": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
-            "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+            "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jest/get-type": "30.1.0",
                 "chalk": "^4.1.2",
-                "jest-diff": "30.3.0",
-                "pretty-format": "30.3.0"
+                "jest-diff": "30.4.1",
+                "pretty-format": "30.4.1"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/jest-message-util": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
-            "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+            "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
-                "@jest/types": "30.3.0",
+                "@jest/types": "30.4.1",
                 "@types/stack-utils": "^2.0.3",
                 "chalk": "^4.1.2",
                 "graceful-fs": "^4.2.11",
+                "jest-util": "30.4.1",
                 "picomatch": "^4.0.3",
-                "pretty-format": "30.3.0",
+                "pretty-format": "30.4.1",
                 "slash": "^3.0.0",
                 "stack-utils": "^2.0.6"
             },
@@ -3001,15 +3025,15 @@
             }
         },
         "node_modules/jest-mock": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
-            "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+            "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/types": "30.3.0",
+                "@jest/types": "30.4.1",
                 "@types/node": "*",
-                "jest-util": "30.3.0"
+                "jest-util": "30.4.1"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -3034,9 +3058,9 @@
             }
         },
         "node_modules/jest-regex-util": {
-            "version": "30.0.1",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
-            "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+            "version": "30.4.0",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3044,18 +3068,18 @@
             }
         },
         "node_modules/jest-resolve": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz",
-            "integrity": "sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
+            "integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "chalk": "^4.1.2",
                 "graceful-fs": "^4.2.11",
-                "jest-haste-map": "30.3.0",
+                "jest-haste-map": "30.4.1",
                 "jest-pnp-resolver": "^1.2.3",
-                "jest-util": "30.3.0",
-                "jest-validate": "30.3.0",
+                "jest-util": "30.4.1",
+                "jest-validate": "30.4.1",
                 "slash": "^3.0.0",
                 "unrs-resolver": "^1.7.11"
             },
@@ -3064,46 +3088,46 @@
             }
         },
         "node_modules/jest-resolve-dependencies": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.3.0.tgz",
-            "integrity": "sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==",
+            "version": "30.4.2",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
+            "integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "jest-regex-util": "30.0.1",
-                "jest-snapshot": "30.3.0"
+                "jest-regex-util": "30.4.0",
+                "jest-snapshot": "30.4.1"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/jest-runner": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.3.0.tgz",
-            "integrity": "sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==",
+            "version": "30.4.2",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
+            "integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/console": "30.3.0",
-                "@jest/environment": "30.3.0",
-                "@jest/test-result": "30.3.0",
-                "@jest/transform": "30.3.0",
-                "@jest/types": "30.3.0",
+                "@jest/console": "30.4.1",
+                "@jest/environment": "30.4.1",
+                "@jest/test-result": "30.4.1",
+                "@jest/transform": "30.4.1",
+                "@jest/types": "30.4.1",
                 "@types/node": "*",
                 "chalk": "^4.1.2",
                 "emittery": "^0.13.1",
                 "exit-x": "^0.2.2",
                 "graceful-fs": "^4.2.11",
-                "jest-docblock": "30.2.0",
-                "jest-environment-node": "30.3.0",
-                "jest-haste-map": "30.3.0",
-                "jest-leak-detector": "30.3.0",
-                "jest-message-util": "30.3.0",
-                "jest-resolve": "30.3.0",
-                "jest-runtime": "30.3.0",
-                "jest-util": "30.3.0",
-                "jest-watcher": "30.3.0",
-                "jest-worker": "30.3.0",
+                "jest-docblock": "30.4.0",
+                "jest-environment-node": "30.4.1",
+                "jest-haste-map": "30.4.1",
+                "jest-leak-detector": "30.4.1",
+                "jest-message-util": "30.4.1",
+                "jest-resolve": "30.4.1",
+                "jest-runtime": "30.4.2",
+                "jest-util": "30.4.1",
+                "jest-watcher": "30.4.1",
+                "jest-worker": "30.4.1",
                 "p-limit": "^3.1.0",
                 "source-map-support": "0.5.13"
             },
@@ -3112,32 +3136,32 @@
             }
         },
         "node_modules/jest-runtime": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.3.0.tgz",
-            "integrity": "sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==",
+            "version": "30.4.2",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
+            "integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/environment": "30.3.0",
-                "@jest/fake-timers": "30.3.0",
-                "@jest/globals": "30.3.0",
+                "@jest/environment": "30.4.1",
+                "@jest/fake-timers": "30.4.1",
+                "@jest/globals": "30.4.1",
                 "@jest/source-map": "30.0.1",
-                "@jest/test-result": "30.3.0",
-                "@jest/transform": "30.3.0",
-                "@jest/types": "30.3.0",
+                "@jest/test-result": "30.4.1",
+                "@jest/transform": "30.4.1",
+                "@jest/types": "30.4.1",
                 "@types/node": "*",
                 "chalk": "^4.1.2",
                 "cjs-module-lexer": "^2.1.0",
                 "collect-v8-coverage": "^1.0.2",
                 "glob": "^10.5.0",
                 "graceful-fs": "^4.2.11",
-                "jest-haste-map": "30.3.0",
-                "jest-message-util": "30.3.0",
-                "jest-mock": "30.3.0",
-                "jest-regex-util": "30.0.1",
-                "jest-resolve": "30.3.0",
-                "jest-snapshot": "30.3.0",
-                "jest-util": "30.3.0",
+                "jest-haste-map": "30.4.1",
+                "jest-message-util": "30.4.1",
+                "jest-mock": "30.4.1",
+                "jest-regex-util": "30.4.0",
+                "jest-resolve": "30.4.1",
+                "jest-snapshot": "30.4.1",
+                "jest-util": "30.4.1",
                 "slash": "^3.0.0",
                 "strip-bom": "^4.0.0"
             },
@@ -3146,9 +3170,9 @@
             }
         },
         "node_modules/jest-snapshot": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
-            "integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+            "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3157,20 +3181,20 @@
                 "@babel/plugin-syntax-jsx": "^7.27.1",
                 "@babel/plugin-syntax-typescript": "^7.27.1",
                 "@babel/types": "^7.27.3",
-                "@jest/expect-utils": "30.3.0",
+                "@jest/expect-utils": "30.4.1",
                 "@jest/get-type": "30.1.0",
-                "@jest/snapshot-utils": "30.3.0",
-                "@jest/transform": "30.3.0",
-                "@jest/types": "30.3.0",
+                "@jest/snapshot-utils": "30.4.1",
+                "@jest/transform": "30.4.1",
+                "@jest/types": "30.4.1",
                 "babel-preset-current-node-syntax": "^1.2.0",
                 "chalk": "^4.1.2",
-                "expect": "30.3.0",
+                "expect": "30.4.1",
                 "graceful-fs": "^4.2.11",
-                "jest-diff": "30.3.0",
-                "jest-matcher-utils": "30.3.0",
-                "jest-message-util": "30.3.0",
-                "jest-util": "30.3.0",
-                "pretty-format": "30.3.0",
+                "jest-diff": "30.4.1",
+                "jest-matcher-utils": "30.4.1",
+                "jest-message-util": "30.4.1",
+                "jest-util": "30.4.1",
+                "pretty-format": "30.4.1",
                 "semver": "^7.7.2",
                 "synckit": "^0.11.8"
             },
@@ -3179,9 +3203,9 @@
             }
         },
         "node_modules/jest-snapshot/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -3192,13 +3216,13 @@
             }
         },
         "node_modules/jest-util": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-            "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/types": "30.3.0",
+                "@jest/types": "30.4.1",
                 "@types/node": "*",
                 "chalk": "^4.1.2",
                 "ci-info": "^4.2.0",
@@ -3210,18 +3234,18 @@
             }
         },
         "node_modules/jest-validate": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.3.0.tgz",
-            "integrity": "sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
+            "integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jest/get-type": "30.1.0",
-                "@jest/types": "30.3.0",
+                "@jest/types": "30.4.1",
                 "camelcase": "^6.3.0",
                 "chalk": "^4.1.2",
                 "leven": "^3.1.0",
-                "pretty-format": "30.3.0"
+                "pretty-format": "30.4.1"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -3241,19 +3265,19 @@
             }
         },
         "node_modules/jest-watcher": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.3.0.tgz",
-            "integrity": "sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
+            "integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/test-result": "30.3.0",
-                "@jest/types": "30.3.0",
+                "@jest/test-result": "30.4.1",
+                "@jest/types": "30.4.1",
                 "@types/node": "*",
                 "ansi-escapes": "^4.3.2",
                 "chalk": "^4.1.2",
                 "emittery": "^0.13.1",
-                "jest-util": "30.3.0",
+                "jest-util": "30.4.1",
                 "string-length": "^4.0.2"
             },
             "engines": {
@@ -3261,15 +3285,15 @@
             }
         },
         "node_modules/jest-worker": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
-            "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
+            "integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
                 "@ungap/structured-clone": "^1.3.0",
-                "jest-util": "30.3.0",
+                "jest-util": "30.4.1",
                 "merge-stream": "^2.0.0",
                 "supports-color": "^8.1.1"
             },
@@ -3411,9 +3435,9 @@
             }
         },
         "node_modules/make-dir/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -3538,9 +3562,9 @@
             "license": "MIT"
         },
         "node_modules/node-releases": {
-            "version": "2.0.38",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-            "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+            "version": "2.0.44",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+            "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -3788,15 +3812,16 @@
             }
         },
         "node_modules/pretty-format": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
-            "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+            "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/schemas": "30.0.5",
+                "@jest/schemas": "30.4.1",
                 "ansi-styles": "^5.2.0",
-                "react-is": "^18.3.1"
+                "react-is-18": "npm:react-is@^18.3.1",
+                "react-is-19": "npm:react-is@^19.2.5"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -3832,10 +3857,19 @@
             ],
             "license": "MIT"
         },
-        "node_modules/react-is": {
+        "node_modules/react-is-18": {
+            "name": "react-is",
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
             "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/react-is-19": {
+            "name": "react-is",
+            "version": "19.2.6",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+            "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
             "dev": true,
             "license": "MIT"
         },
@@ -4294,9 +4328,9 @@
             }
         },
         "node_modules/ts-jest/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -4448,38 +4482,39 @@
             "license": "MIT"
         },
         "node_modules/unrs-resolver": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
-            "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.0.tgz",
+            "integrity": "sha512-hiJjN9x3O/SF2yGpNX7swfg24bi4t+uqEww16EeH9LT2I6mkGNf8uZvAS9PL1pvkA/fBagTaxbgHfYQPRfahuQ==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "napi-postinstall": "^0.3.0"
+                "napi-postinstall": "^0.3.4"
             },
             "funding": {
                 "url": "https://opencollective.com/unrs-resolver"
             },
             "optionalDependencies": {
-                "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
-                "@unrs/resolver-binding-android-arm64": "1.11.1",
-                "@unrs/resolver-binding-darwin-arm64": "1.11.1",
-                "@unrs/resolver-binding-darwin-x64": "1.11.1",
-                "@unrs/resolver-binding-freebsd-x64": "1.11.1",
-                "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
-                "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
-                "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
-                "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
-                "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
-                "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
-                "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
-                "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
-                "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+                "@unrs/resolver-binding-android-arm-eabi": "1.12.0",
+                "@unrs/resolver-binding-android-arm64": "1.12.0",
+                "@unrs/resolver-binding-darwin-arm64": "1.12.0",
+                "@unrs/resolver-binding-darwin-x64": "1.12.0",
+                "@unrs/resolver-binding-freebsd-x64": "1.12.0",
+                "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.0",
+                "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.0",
+                "@unrs/resolver-binding-linux-arm64-gnu": "1.12.0",
+                "@unrs/resolver-binding-linux-arm64-musl": "1.12.0",
+                "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.0",
+                "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.0",
+                "@unrs/resolver-binding-linux-riscv64-musl": "1.12.0",
+                "@unrs/resolver-binding-linux-s390x-gnu": "1.12.0",
+                "@unrs/resolver-binding-linux-x64-gnu": "1.12.0",
+                "@unrs/resolver-binding-linux-x64-musl": "1.12.0",
+                "@unrs/resolver-binding-openharmony-arm64": "1.12.0",
+                "@unrs/resolver-binding-wasm32-wasi": "1.12.0",
+                "@unrs/resolver-binding-win32-arm64-msvc": "1.12.0",
+                "@unrs/resolver-binding-win32-ia32-msvc": "1.12.0",
+                "@unrs/resolver-binding-win32-x64-msvc": "1.12.0"
             }
         },
         "node_modules/update-browserslist-db": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@actions/core": "^3.0.0",
                 "@actions/exec": "^3.0.0",
-                "common-utils": "github:matlab-actions/common-utils#v2.2.2"
+                "common-utils": "github:matlab-actions/common-utils#kapilg/opt-out"
             },
             "devDependencies": {
                 "@types/jest": "^30.0.0",
@@ -2071,7 +2071,7 @@
         },
         "node_modules/common-utils": {
             "version": "2.2.2",
-            "resolved": "git+ssh://git@github.com/matlab-actions/common-utils.git#380f02f66aa218bc294b769694fc4772ad159b93",
+            "resolved": "git+ssh://git@github.com/matlab-actions/common-utils.git#46035938d4cb236d431d3d07ff44ea4b2b0c8f24",
             "dependencies": {
                 "@actions/core": "^3.0.0",
                 "@actions/exec": "^3.0.0",
@@ -2185,9 +2185,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.344",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
-            "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+            "version": "1.5.345",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.345.tgz",
+            "integrity": "sha512-F9JXQGiMrz6yVNPI2qOVPvB9HzjH5cGzhs8oJ6A28V5L/YnzN/0KsuiibqF+F1Fd9qxFzD1BUnYSd8JfULxTwg==",
             "dev": true,
             "license": "ISC"
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@actions/core": "^3.0.0",
                 "@actions/exec": "^3.0.0",
-                "common-utils": "github:matlab-actions/common-utils#kapilg/opt-out"
+                "common-utils": "github:matlab-actions/common-utils#v2.3.0"
             },
             "devDependencies": {
                 "@types/jest": "^30.0.0",
@@ -2070,8 +2070,8 @@
             "license": "MIT"
         },
         "node_modules/common-utils": {
-            "version": "2.2.2",
-            "resolved": "git+ssh://git@github.com/matlab-actions/common-utils.git#3b9beb354d5949f1f68105ad1cabfe865959fa60",
+            "version": "2.3.0",
+            "resolved": "git+ssh://git@github.com/matlab-actions/common-utils.git#2d9ace4eed6057ceddb027a33924b568fd4e2f5f",
             "dependencies": {
                 "@actions/core": "^3.0.0",
                 "@actions/exec": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,9 +75,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-            "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+            "version": "7.29.3",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+            "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -246,9 +246,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+            "version": "7.29.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1103,9 +1103,9 @@
             }
         },
         "node_modules/@sinonjs/fake-timers": {
-            "version": "15.3.2",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
-            "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+            "version": "15.4.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+            "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -1141,9 +1141,9 @@
             "license": "MIT"
         },
         "node_modules/@tybys/wasm-util": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -1776,9 +1776,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.24",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
-            "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
+            "version": "2.10.27",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+            "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -2071,7 +2071,7 @@
         },
         "node_modules/common-utils": {
             "version": "2.2.2",
-            "resolved": "git+ssh://git@github.com/matlab-actions/common-utils.git#46035938d4cb236d431d3d07ff44ea4b2b0c8f24",
+            "resolved": "git+ssh://git@github.com/matlab-actions/common-utils.git#3b9beb354d5949f1f68105ad1cabfe865959fa60",
             "dependencies": {
                 "@actions/core": "^3.0.0",
                 "@actions/exec": "^3.0.0",
@@ -2185,9 +2185,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.345",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.345.tgz",
-            "integrity": "sha512-F9JXQGiMrz6yVNPI2qOVPvB9HzjH5cGzhs8oJ6A28V5L/YnzN/0KsuiibqF+F1Fd9qxFzD1BUnYSd8JfULxTwg==",
+            "version": "1.5.351",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.351.tgz",
+            "integrity": "sha512-9D7Iqx8RImSvCnOsj86rCH6eQjZFQoM04Jn6HnZVM0Nu/G58/gmKYQ1d12MZTbjQbQSTGI8nwEy07ErsA2slLA==",
             "dev": true,
             "license": "ISC"
         },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dependencies": {
         "@actions/core": "^3.0.0",
         "@actions/exec": "^3.0.0",
-        "common-utils": "github:matlab-actions/common-utils#v2.3.0"
+        "common-utils": "github:matlab-actions/common-utils#v2.3.1"
     },
     "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dependencies": {
         "@actions/core": "^3.0.0",
         "@actions/exec": "^3.0.0",
-        "common-utils": "github:matlab-actions/common-utils#kapilg/opt-out"
+        "common-utils": "github:matlab-actions/common-utils#v2.3.0"
     },
     "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dependencies": {
         "@actions/core": "^3.0.0",
         "@actions/exec": "^3.0.0",
-        "common-utils": "github:matlab-actions/common-utils#v2.2.2"
+        "common-utils": "github:matlab-actions/common-utils#kapilg/opt-out"
     },
     "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ async function run() {
 
     const command = core.getInput("command");
     const startupOpts = core.getInput("startup-options").split(" ");
-    const generateJobSummary = core.getBooleanInput("generate-job-summary");
+    const generateSummary = core.getBooleanInput("generate-summary");
 
     const helperScript = await matlab.generateScript(workspaceDir, command);
     const execOpts = {
@@ -22,7 +22,7 @@ async function run() {
             ...process.env,
             MW_BATCH_LICENSING_ONLINE: "true", // Remove when online batch licensing is the default
             MW_MATLAB_BUILDTOOL_DEFAULT_PLUGINS_FCN_OVERRIDE: "buildframework.getDefaultPlugins",
-            MW_GENERATE_JOB_SUMMARY: String(generateJobSummary),
+            MW_GENERATE_SUMMARY: String(generateSummary),
         },
     };
     await matlab
@@ -34,7 +34,7 @@ async function run() {
             startupOpts,
         )
         .finally(() => {
-            if (generateJobSummary) {
+            if (generateSummary) {
                 const runnerTemp = process.env.RUNNER_TEMP || "";
                 const runId = process.env.GITHUB_RUN_ID || "";
                 const actionName = process.env.GITHUB_ACTION || "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ async function run() {
             ...process.env,
             MW_BATCH_LICENSING_ONLINE: "true", // Remove when online batch licensing is the default
             MW_MATLAB_BUILDTOOL_DEFAULT_PLUGINS_FCN_OVERRIDE: "buildframework.getDefaultPlugins",
-            MW_GENERATE_SUMMARY: String(generateSummary),
+            MW_INPUT_GENERATE_SUMMARY: String(generateSummary),
         },
     };
     await matlab

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,12 @@ async function run() {
                 const actionName = process.env.GITHUB_ACTION || "";
 
                 buildSummary.processAndAddBuildSummary(runnerTemp, actionName);
-                testResultsSummary.processAndAddTestSummary(runnerTemp, runId, actionName, workspaceDir);
+                testResultsSummary.processAndAddTestSummary(
+                    runnerTemp,
+                    runId,
+                    actionName,
+                    workspaceDir,
+                );
                 core.summary.write();
             }
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ async function run() {
 
     const command = core.getInput("command");
     const startupOpts = core.getInput("startup-options").split(" ");
+    const generateJobSummary = core.getBooleanInput("generate-job-summary");
 
     const helperScript = await matlab.generateScript(workspaceDir, command);
     const execOpts = {
@@ -21,6 +22,7 @@ async function run() {
             ...process.env,
             MW_BATCH_LICENSING_ONLINE: "true", // Remove when online batch licensing is the default
             MW_MATLAB_BUILDTOOL_DEFAULT_PLUGINS_FCN_OVERRIDE: "buildframework.getDefaultPlugins",
+            MW_GENERATE_JOB_SUMMARY: String(generateJobSummary),
         },
     };
     await matlab
@@ -32,12 +34,15 @@ async function run() {
             startupOpts,
         )
         .finally(() => {
-            const runnerTemp = process.env.RUNNER_TEMP || "";
-            const runId = process.env.GITHUB_RUN_ID || "";
+            if (generateJobSummary) {
+                const runnerTemp = process.env.RUNNER_TEMP || "";
+                const runId = process.env.GITHUB_RUN_ID || "";
+                const actionName = process.env.GITHUB_ACTION || "";
 
-            buildSummary.processAndAddBuildSummary(runnerTemp, runId);
-            testResultsSummary.processAndAddTestSummary(runnerTemp, runId, workspaceDir);
-            core.summary.write();
+                buildSummary.processAndAddBuildSummary(runnerTemp, actionName);
+                testResultsSummary.processAndAddTestSummary(runnerTemp, runId, actionName, workspaceDir);
+                core.summary.write();
+            }
         });
 }
 


### PR DESCRIPTION
## Summary
- Add `generate-summary` boolean input (default: `true`) that allows users to disable MATLAB-related job summary generation
- Pass `MW_GENERATE_SUMMARY` environment variable to MATLAB so plugin services can skip artifact creation when disabled
- Update summary function call signatures to use `actionName` for artifact scoping

### Usage

```
- uses: matlab-actions/run-command@v3
  with:
      generate-summary: false
``` 